### PR TITLE
Add ability to "play" stories with DebugParser.

### DIFF
--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -11,7 +11,13 @@ angular.module('DebugEditorApp', [
 .factory('_', () -> return _)
 
 .controller('DebugEditorCtrl', ['$scope', '_', 'DebugParser', ($scope, _, DebugParser) ->
-  $scope.nodes = {}
+  # Load nodes from localStorage if present; otherwise, start with empty nodes.
+  try
+    parsed_nodes = JSON.parse(localStorage.getItem('yarnNodes'))
+  catch error
+    parsed_nodes = undefined
+    console.log(error)
+  $scope.nodes = parsed_nodes || {}
 
   $scope.update_node_text = (node_id, node_text) ->
     $scope.nodes[node_id] = node_text
@@ -32,7 +38,21 @@ angular.module('DebugEditorApp', [
 
   $scope.graph = DebugParser.compile_graph($scope.nodes)
 
-  $scope.$watch('nodes', () ->
-    $scope.graph = DebugParser.compile_graph($scope.nodes)
-  , true)
+  $scope.$watch('nodes',
+    () ->
+      $scope.graph = DebugParser.compile_graph($scope.nodes)
+    , true)
+
+  $scope.save_story = ->
+    localStorage.setItem('yarnNodes',
+                         JSON.stringify($scope.nodes))
+    localStorage.setItem('yarnStory',
+                         DebugParser.compile_page($scope.nodes))
+
+  $scope.launch_story = ->
+    $scope.save_story()
+    window.open('/play.html')
+
+  $scope.new_story = ->
+    $scope.nodes = {}
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -8,15 +8,18 @@ angular.module('DebugEditorApp', [
 
 .service('DebugParser', DebugParser)
 
-.factory('_', () -> return _)
+.factory('localStorage', -> localStorage)
+.factory('_', -> return _)
 
-.controller('DebugEditorCtrl', ['$scope', '_', 'DebugParser', ($scope, _, DebugParser) ->
+.controller('DebugEditorCtrl',
+['$scope', '$window', '_', 'DebugParser', 'localStorage',
+($scope, $window, _, DebugParser, localStorage) ->
   # Load nodes from localStorage if present; otherwise, start with empty nodes.
   try
     parsed_nodes = JSON.parse(localStorage.getItem('yarnNodes'))
   catch error
     parsed_nodes = undefined
-    console.log(error)
+    console.log('Error deserializing nodes from localStorage: ' + error)
   $scope.nodes = parsed_nodes || {}
 
   $scope.update_node_text = (node_id, node_text) ->
@@ -38,8 +41,7 @@ angular.module('DebugEditorApp', [
 
   $scope.graph = DebugParser.compile_graph($scope.nodes)
 
-  $scope.$watch('nodes',
-    () ->
+  $scope.$watch('nodes', ->
       $scope.graph = DebugParser.compile_graph($scope.nodes)
     , true)
 
@@ -51,7 +53,7 @@ angular.module('DebugEditorApp', [
 
   $scope.launch_story = ->
     $scope.save_story()
-    window.open('/play.html')
+    $window.open('/play.html')
 
   $scope.new_story = ->
     $scope.nodes = {}

--- a/app/index.html
+++ b/app/index.html
@@ -47,6 +47,24 @@
 
       </div>
 
+      <button type="submit"
+        ng-click="save_story()"
+        class="btn btn-primary">
+          Save
+      </button>
+
+      <button type="submit"
+        ng-click="launch_story()"
+        class="btn btn-primary">
+          Play Story
+      </button>
+
+      <button type="submit"
+        ng-click="new_story()"
+        class="btn btn-primary">
+          Clear Story
+      </button>
+
     </div>
 
     <!-- bower:js -->

--- a/app/index.html
+++ b/app/index.html
@@ -47,22 +47,19 @@
 
       </div>
 
-      <button type="submit"
-        ng-click="save_story()"
-        class="btn btn-primary">
-          Save
+      <button type="submit" class="btn btn-primary"
+          ng-click="save_story()">
+        Save
       </button>
 
-      <button type="submit"
-        ng-click="launch_story()"
-        class="btn btn-primary">
-          Play Story
+      <button type="submit" class="btn btn-primary"
+          ng-click="launch_story()">
+        Play Story
       </button>
 
-      <button type="submit"
-        ng-click="new_story()"
-        class="btn btn-primary">
-          Clear Story
+      <button type="submit" class="btn btn-primary"
+          ng-click="new_story()">
+        Clear Story
       </button>
 
     </div>

--- a/app/main.coffee
+++ b/app/main.coffee
@@ -51,4 +51,5 @@ class DebugParser extends Parser
       page += _.template(node_template)(title: title, text: text)
     return page
 
+window.Edge = Edge
 window.DebugParser = DebugParser

--- a/app/main.coffee
+++ b/app/main.coffee
@@ -41,4 +41,14 @@ class DebugParser extends Parser
 
     return edges
 
+  compile_page: (nodes) ->
+    page = ''
+    for title, text of nodes
+      node_template = """
+                      <h1><%- title %></h1>
+                      <p><%- text %></p>
+                      """
+      page += _.template(node_template)(title: title, text: text)
+    return page
+
 window.DebugParser = DebugParser

--- a/app/main.spec.coffee
+++ b/app/main.spec.coffee
@@ -1,4 +1,11 @@
-describe 'Placeholder test', () ->
 
-    it 'should pass', () ->
-        expect(true).toBe(true)
+test_nodes =
+  start: 'Hello! I am the first node. Go to the [second] one. Or the [third] one.'
+  second: 'Hi! Second node here. Go to the [third]!'
+  third: "That's all folks."
+
+
+describe 'Debug Parser', () ->
+  it 'should produce a page which contains the start node text', () ->
+    page = new DebugParser().compile_page(test_nodes)
+    expect(page).toContain(test_nodes['start'])

--- a/app/main.spec.coffee
+++ b/app/main.spec.coffee
@@ -1,11 +1,11 @@
 
-test_nodes =
-  start: 'Hello! I am the first node. Go to the [second] one. Or the [third] one.'
-  second: 'Hi! Second node here. Go to the [third]!'
-  third: "That's all folks."
+describe 'Debug Parser', ->
+  test_nodes =
+    start: 'Hello! I am the first node. Go to the [second] one. Or the [third] one.'
+    second: 'Hi! Second node here. Go to the [third]!'
+    third: "That's all folks."
 
-
-describe 'Debug Parser', () ->
-  it 'should produce a page which contains the start node text', () ->
-    page = new DebugParser().compile_page(test_nodes)
-    expect(page).toContain(test_nodes['start'])
+  describe '#compile_page', ->
+    it 'should produce a page which contains the start node text', ->
+      page = new DebugParser().compile_page(test_nodes)
+      expect(page).toContain(test_nodes['start'])

--- a/app/main.spec.coffee
+++ b/app/main.spec.coffee
@@ -1,11 +1,32 @@
 
 describe 'Debug Parser', ->
-  test_nodes =
+  TEST_NODES =
     start: 'Hello! I am the first node. Go to the [second] one. Or the [third] one.'
     second: 'Hi! Second node here. Go to the [third]!'
     third: "That's all folks."
 
   describe '#compile_page', ->
     it 'should produce a page which contains the start node text', ->
-      page = new DebugParser().compile_page(test_nodes)
-      expect(page).toContain(test_nodes['start'])
+      page = new DebugParser().compile_page(TEST_NODES)
+      expect(page).toContain(TEST_NODES['start'])
+
+  describe '#compile_edges', ->
+    it 'should parse out both links from the start node', ->
+      graph = new DebugParser().compile_graph(TEST_NODES)
+      edges = graph.edges_by_node('start')
+
+      expect(edges.length).toEqual(2)
+      expect(edges).toContain(new Edge('start', 'second'))
+      expect(edges).toContain(new Edge('start', 'third'))
+
+    it 'should parse out the sole link from the second node', ->
+      graph = new DebugParser().compile_graph(TEST_NODES)
+      edges = graph.edges_by_node('second')
+
+      expect(edges).toEqual([new Edge('second', 'third')])
+
+    it 'should not have any links from the third node', ->
+      graph = new DebugParser().compile_graph(TEST_NODES)
+      edges = graph.edges_by_node('third')
+
+      expect(edges).toEqual([])

--- a/app/main.spec.coffee
+++ b/app/main.spec.coffee
@@ -10,7 +10,7 @@ describe 'Debug Parser', ->
       page = new DebugParser().compile_page(TEST_NODES)
       expect(page).toContain(TEST_NODES['start'])
 
-  describe '#compile_edges', ->
+  describe '#compile_graph', ->
     it 'should parse out both links from the start node', ->
       graph = new DebugParser().compile_graph(TEST_NODES)
       edges = graph.edges_by_node('start')

--- a/app/play.html
+++ b/app/play.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <script>
+      (function() {
+        var storyHtml = localStorage.getItem('yarnStory');
+        window.onload = function() {
+          document.documentElement.innerHTML = storyHtml;
+        }
+      })();
+    </script>
+  </head>
+
+  <body></body>
+</html>

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "lodash": "~3.3.x",
     "angular": "~1.3.x",
     "angular-xeditable": "~0.1.8",
-    "bootstrap": "~3.3.2"
+    "bootstrap": "~3.3.2",
+    "jquery": "2.1.x"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,9 +6,11 @@ module.exports = function(config){
     // List of files/patterns to load in the browser
     files : [
       // bower:js
+      'app/bower_components/jquery/dist/jquery.js',
       'app/bower_components/lodash/lodash.js',
       'app/bower_components/angular/angular.js',
       'app/bower_components/angular-xeditable/dist/js/xeditable.js',
+      'app/bower_components/bootstrap/dist/js/bootstrap.js',
       // endbower
       '.dev/main.js',
       'app/**.spec.coffee',


### PR DESCRIPTION
Allow users to play their stories while editing,
by opening a new window and loading the compiled story from localStorage.

Also use localStorage to have the Editor persist its set of nodes across
refreshes.