### PR TITLE
Add support for multiple stories

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
       scripts: [
         '<%= config.dirs.app %>/main.coffee',
         '<%= config.dirs.app %>/debug-parser/debug-parser.coffee',
+        '<%= config.dirs.app %>/editor/story.coffee',
         '<%= config.dirs.app %>/editor/editor.coffee',
       ],
       tests: [

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -61,8 +61,11 @@ angular.module('DebugEditorApp', [
     $scope.graph = DebugParser.compile_graph($scope.story.nodes)
 
   $scope.add_node_to_story = (node_id, node_text='') ->
-    added_node = $scope.story.add_node(node_id, node_text)
-    $scope.new_node = {} if added_node
+    try
+      $scope.story.add_node(node_id, node_text)
+      $scope.new_node = {}
+    catch error
+      alert(error)
 
   $scope.launch_story = ->
     $window.open('/play.html#' + $scope.story.id)

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -82,10 +82,10 @@ angular.module('DebugEditorApp', [
 
   $scope.x_edit = (callback, args...) ->
     try
-      console.log('complete')
+      callback(args...)
       return true
     catch error
-      return error
+      return "#{error}"
 
   # Watch $scope.story
   $scope.$watch('story', ->

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -11,11 +11,13 @@ angular.module('DebugEditorApp', [
   $routeProvider
   .when('/stories', {
     templateUrl: 'editor/editor.html',
-    controller: 'DebugEditorCtrl'
+    controller: 'DebugEditorCtrl',
+    controllerAs: 'editor'
   })
   .when('/stories/:id', {
     templateUrl: 'editor/editor.html',
-    controller: 'DebugEditorCtrl'
+    controller: 'DebugEditorCtrl',
+    controllerAs: 'editor'
   })
   .otherwise({
     redirectTo: '/stories'
@@ -35,13 +37,26 @@ angular.module('DebugEditorApp', [
 ])
 
 .controller('DebugEditorCtrl',
-['$scope', '$window', '$routeParams', '_', 'DebugParser', 'localStorage', 'DebugStory', 'DebugStoryStorage',
-($scope, $window, $routeParams, _, DebugParser, localStorage, DebugStory, DebugStoryStorage) ->
+['$scope', '$window', '$routeParams', '$location', '_', 'DebugParser', 'DebugStory', 'DebugStoryStorage',
+($scope, $window, $routeParams, $location, _, DebugParser, DebugStory, DebugStoryStorage) ->
+
+  # Load all stories
+  $scope.stories = DebugStoryStorage.stories()
+
+  # If viewing a story, set story
+  if $routeParams.id
+    $scope.story = $scope.stories[$routeParams.id]
 
   # Debug Editor Methods
+  $scope.go_to_story = () ->
+    story_id = if $scope.story then $scope.story.id else ''
+    $location.path('/stories/' + story_id)
+
   $scope.new_story = ->
     $scope.story = new DebugStory()
+    $scope.go_to_story()
     $scope.stories[$scope.story.id] = $scope.story
+    $scope.graph = DebugParser.compile_graph($scope.story.nodes)
 
   $scope.add_node_to_story = (node_id, node_text='') ->
     added_node = $scope.story.add_node(node_id, node_text)
@@ -53,26 +68,16 @@ angular.module('DebugEditorApp', [
 
   $scope.clear_stories = ->
     $scope.stories = {}
+    $scope.story = undefined
+    $scope.go_to_story()
     DebugStoryStorage.clear()
-    $scope.new_story()
 
-  # Load all stories
-  $scope.stories = DebugStoryStorage.stories()
-
-  # Load current story_id from localStorage if present; otherwise create a new story_id
-  story_id = localStorage.getItem('yarn-story-id')
-
-  if story_id
-    $scope.story = $scope.stories[story_id]
-  else
-    console.log('Could not get current story_id from localStorage.')
-    $scope.new_story()
-
-  # Debug Editor Graph
-  $scope.graph = DebugParser.compile_graph($scope.story.nodes)
+  $scope.has_stories = ->
+    return !_.isEmpty($scope.stories)
 
   $scope.$watch('story', ->
-      DebugStoryStorage.save_story($scope.story)
-      $scope.graph = DebugParser.compile_graph($scope.story.nodes)
+      if $scope.story
+        DebugStoryStorage.save_story($scope.story)
+        $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -22,23 +22,16 @@ angular.module('DebugEditorApp', [
 ['$scope', '$window', '_', 'DebugParser', 'localStorage', 'DebugStory', 'StoryStorage',
 ($scope, $window, _, DebugParser, localStorage, DebugStory, StoryStorage) ->
 
-  # Set story_ids
-  $scope.story_ids = StoryStorage.story_ids()
-
   # Debug Editor Methods
-  $scope.edit_story = (id) ->
-    localStorage.setItem('yarn-story-id', id)
-    $scope.story = StoryStorage.load_story(id)
-
   $scope.save_story = ->
     StoryStorage.save_story($scope.story)
+    localStorage.setItem('yarn-story-id', $scope.story.id)
 
   $scope.new_story = ->
     $scope.story = new DebugStory()
     localStorage.setItem('yarn-story-id', $scope.story.id)
     $scope.save_story()
-    $scope.chosen_story_id = $scope.story.id
-    $scope.story_ids = StoryStorage.story_ids()
+    $scope.stories[$scope.story.id] = $scope.story
 
   $scope.add_node_to_story = (node_id, node_text='') ->
     added_node = $scope.story.add_node(node_id, node_text)
@@ -49,22 +42,25 @@ angular.module('DebugEditorApp', [
     $window.open('/play.html')
 
   $scope.clear_stories = ->
+    $scope.stories = {}
     StoryStorage.clear()
     $scope.new_story()
+
+  $scope.stories = StoryStorage.stories()
 
   # Load current story_id from localStorage if present; otherwise create a new story_id
   story_id = localStorage.getItem('yarn-story-id')
 
   if story_id
-    $scope.story = StoryStorage.load_story(story_id)
-    $scope.chosen_story_id = $scope.story.id
+    $scope.story = $scope.stories[story_id]
   else
     console.log('Could not get current story_id from localStorage.')
     $scope.new_story()
 
+  # Debug Editor Graph
   $scope.graph = DebugParser.compile_graph($scope.story.nodes)
 
-  $scope.$watch('nodes', ->
+  $scope.$watch('story.nodes', ->
       $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -50,6 +50,7 @@ angular.module('DebugEditorApp', [
 
   $scope.launch_story = ->
     $window.open('/play.html#' + $scope.story.id)
+    return true
 
   $scope.clear_stories = ->
     $scope.stories = {}

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -30,20 +30,20 @@ angular.module('DebugEditorApp', [
 
 .service('DebugParser', Yarn.DebugParser)
 
-.factory('DebugStory', -> DebugStory)
+.factory('Story', -> Story)
 
-.factory('DebugStoryStorage',
+.factory('StoryStorage',
 ['localStorage', 'DebugParser',
 (localStorage, DebugParser) ->
-  return new DebugStoryStorage(localStorage, DebugParser)
+  return new StoryStorage(localStorage, DebugParser)
 ])
 
 .controller('DebugEditorCtrl',
-['$scope', '$window', '$routeParams', '$location', '_', 'DebugParser', 'DebugStory', 'DebugStoryStorage',
-($scope, $window, $routeParams, $location, _, DebugParser, DebugStory, DebugStoryStorage) ->
+['$scope', '$window', '$routeParams', '$location', '_', 'DebugParser', 'Story', 'StoryStorage',
+($scope, $window, $routeParams, $location, _, DebugParser, Story, StoryStorage) ->
 
   # Load all stories
-  $scope.stories = DebugStoryStorage.stories()
+  $scope.stories = StoryStorage.stories()
 
   # If viewing a story, set story
   if $routeParams.id
@@ -55,7 +55,7 @@ angular.module('DebugEditorApp', [
     $location.path('/stories/' + story_id)
 
   $scope.new_story = ->
-    $scope.story = new DebugStory()
+    $scope.story = new Story()
     $scope.go_to_story()
     $scope.stories[$scope.story.id] = $scope.story
     $scope.graph = DebugParser.compile_graph($scope.story.nodes)
@@ -75,7 +75,7 @@ angular.module('DebugEditorApp', [
     $scope.stories = {}
     $scope.story = undefined
     $scope.go_to_story()
-    DebugStoryStorage.clear()
+    StoryStorage.clear()
 
   $scope.has_stories = ->
     return !_.isEmpty($scope.stories)
@@ -83,7 +83,7 @@ angular.module('DebugEditorApp', [
   # Watch $scope.story
   $scope.$watch('story', ->
       if $scope.story
-        DebugStoryStorage.save_story($scope.story)
+        StoryStorage.save_story($scope.story)
         $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -23,14 +23,9 @@ angular.module('DebugEditorApp', [
 ($scope, $window, _, DebugParser, localStorage, DebugStory, StoryStorage) ->
 
   # Debug Editor Methods
-  $scope.save_story = ->
-    StoryStorage.save_story($scope.story)
-    localStorage.setItem('yarn-story-id', $scope.story.id)
-
   $scope.new_story = ->
     $scope.story = new DebugStory()
     localStorage.setItem('yarn-story-id', $scope.story.id)
-    $scope.save_story()
     $scope.stories[$scope.story.id] = $scope.story
 
   $scope.add_node_to_story = (node_id, node_text='') ->
@@ -38,7 +33,6 @@ angular.module('DebugEditorApp', [
     $scope.new_node = {} if added_node
 
   $scope.launch_story = ->
-    $scope.save_story()
     $window.open('/play.html')
 
   $scope.clear_stories = ->
@@ -46,6 +40,7 @@ angular.module('DebugEditorApp', [
     StoryStorage.clear()
     $scope.new_story()
 
+  # Load all stories
   $scope.stories = StoryStorage.stories()
 
   # Load current story_id from localStorage if present; otherwise create a new story_id
@@ -60,7 +55,9 @@ angular.module('DebugEditorApp', [
   # Debug Editor Graph
   $scope.graph = DebugParser.compile_graph($scope.story.nodes)
 
-  $scope.$watch('story.nodes', ->
+  $scope.$watch('story', ->
+      StoryStorage.save_story($scope.story)
+      localStorage.setItem('yarn-story-id', $scope.story.id)
       $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -9,7 +9,8 @@ angular.module('DebugEditorApp', [
 .service('DebugParser', Yarn.DebugParser)
 
 .factory('localStorage', -> localStorage)
-.factory('_', -> return _)
+
+.factory('_', -> _)
 
 .controller('DebugEditorCtrl',
 ['$scope', '$window', '_', 'DebugParser', 'localStorage',

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -1,26 +1,42 @@
 angular.module('DebugEditorApp', [
-  'xeditable'
+  'xeditable',
+  'ngRoute'
 ])
 
 .run((editableOptions) ->
   editableOptions.theme = 'bs3'
 )
 
-.service('DebugParser', Yarn.DebugParser)
+.config(['$routeProvider', ($routeProvider) ->
+  $routeProvider
+  .when('/stories', {
+    templateUrl: 'editor/editor.html',
+    controller: 'DebugEditorCtrl'
+  })
+  .when('/stories/:id', {
+    templateUrl: 'editor/editor.html',
+    controller: 'DebugEditorCtrl'
+  })
+  .otherwise({
+    redirectTo: '/stories'
+  })
+])
 
 .factory('localStorage', -> localStorage)
 
 .factory('_', -> _)
 
+.service('DebugParser', Yarn.DebugParser)
+
 .factory('DebugStory', -> DebugStory)
 
-.factory('StoryStorage', ['localStorage', (localStorage) ->
-  return new StoryStorage(localStorage)
+.factory('DebugStoryStorage', ['localStorage', (localStorage) ->
+  return new DebugStoryStorage(localStorage)
 ])
 
 .controller('DebugEditorCtrl',
-['$scope', '$window', '_', 'DebugParser', 'localStorage', 'DebugStory', 'StoryStorage',
-($scope, $window, _, DebugParser, localStorage, DebugStory, StoryStorage) ->
+['$scope', '$window', '$routeParams', '_', 'DebugParser', 'localStorage', 'DebugStory', 'DebugStoryStorage',
+($scope, $window, $routeParams, _, DebugParser, localStorage, DebugStory, DebugStoryStorage) ->
 
   # Debug Editor Methods
   $scope.new_story = ->
@@ -37,11 +53,11 @@ angular.module('DebugEditorApp', [
 
   $scope.clear_stories = ->
     $scope.stories = {}
-    StoryStorage.clear()
+    DebugStoryStorage.clear()
     $scope.new_story()
 
   # Load all stories
-  $scope.stories = StoryStorage.stories()
+  $scope.stories = DebugStoryStorage.stories()
 
   # Load current story_id from localStorage if present; otherwise create a new story_id
   story_id = localStorage.getItem('yarn-story-id')
@@ -56,7 +72,7 @@ angular.module('DebugEditorApp', [
   $scope.graph = DebugParser.compile_graph($scope.story.nodes)
 
   $scope.$watch('story', ->
-      StoryStorage.save_story($scope.story)
+      DebugStoryStorage.save_story($scope.story)
       localStorage.setItem('yarn-story-id', $scope.story.id)
       $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -75,6 +75,7 @@ angular.module('DebugEditorApp', [
   $scope.has_stories = ->
     return !_.isEmpty($scope.stories)
 
+  # Watch $scope.story
   $scope.$watch('story', ->
       if $scope.story
         DebugStoryStorage.save_story($scope.story)

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -32,8 +32,10 @@ angular.module('DebugEditorApp', [
 
 .factory('DebugStory', -> DebugStory)
 
-.factory('DebugStoryStorage', ['localStorage', (localStorage) ->
-  return new DebugStoryStorage(localStorage)
+.factory('DebugStoryStorage',
+['localStorage', 'DebugParser',
+(localStorage, DebugParser) ->
+  return new DebugStoryStorage(localStorage, DebugParser)
 ])
 
 .controller('DebugEditorCtrl',

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -49,7 +49,7 @@ angular.module('DebugEditorApp', [
     $scope.new_node = {} if added_node
 
   $scope.launch_story = ->
-    $window.open('/play.html')
+    $window.open('/play.html#' + $scope.story.id)
 
   $scope.clear_stories = ->
     $scope.stories = {}

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -41,7 +41,6 @@ angular.module('DebugEditorApp', [
   # Debug Editor Methods
   $scope.new_story = ->
     $scope.story = new DebugStory()
-    localStorage.setItem('yarn-story-id', $scope.story.id)
     $scope.stories[$scope.story.id] = $scope.story
 
   $scope.add_node_to_story = (node_id, node_text='') ->
@@ -74,7 +73,6 @@ angular.module('DebugEditorApp', [
 
   $scope.$watch('story', ->
       DebugStoryStorage.save_story($scope.story)
-      localStorage.setItem('yarn-story-id', $scope.story.id)
       $scope.graph = DebugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -80,6 +80,13 @@ angular.module('DebugEditorApp', [
   $scope.has_stories = ->
     return !_.isEmpty($scope.stories)
 
+  $scope.x_edit = (callback, args...) ->
+    try
+      console.log('complete')
+      return true
+    catch error
+      return error
+
   # Watch $scope.story
   $scope.$watch('story', ->
       if $scope.story

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -28,22 +28,22 @@ angular.module('DebugEditorApp', [
 
 .factory('_', -> _)
 
-.service('DebugParser', Yarn.DebugParser)
+.service('debugParser', Yarn.DebugParser)
 
 .factory('Story', -> Story)
 
-.factory('StoryStorage',
-['localStorage', 'DebugParser',
-(localStorage, DebugParser) ->
-  return new StoryStorage(localStorage, DebugParser)
+.factory('storyStorage',
+['localStorage', 'debugParser',
+(localStorage, debugParser) ->
+  return new StoryStorage(localStorage, debugParser)
 ])
 
 .controller('DebugEditorCtrl',
-['$scope', '$window', '$routeParams', '$location', '_', 'DebugParser', 'Story', 'StoryStorage',
-($scope, $window, $routeParams, $location, _, DebugParser, Story, StoryStorage) ->
+['$scope', '$window', '$routeParams', '$location', '_', 'debugParser', 'Story', 'storyStorage',
+($scope, $window, $routeParams, $location, _, debugParser, Story, storyStorage) ->
 
   # Load all stories
-  $scope.stories = StoryStorage.stories()
+  $scope.stories = storyStorage.stories()
 
   # If viewing a story, set story
   if $routeParams.id
@@ -58,7 +58,7 @@ angular.module('DebugEditorApp', [
     $scope.story = new Story()
     $scope.go_to_story()
     $scope.stories[$scope.story.id] = $scope.story
-    $scope.graph = DebugParser.compile_graph($scope.story.nodes)
+    $scope.graph = debugParser.compile_graph($scope.story.nodes)
 
   $scope.add_node_to_story = (node_id, node_text='') ->
     try
@@ -75,7 +75,7 @@ angular.module('DebugEditorApp', [
     $scope.stories = {}
     $scope.story = undefined
     $scope.go_to_story()
-    StoryStorage.clear()
+    storyStorage.clear()
 
   $scope.has_stories = ->
     return !_.isEmpty($scope.stories)
@@ -83,7 +83,7 @@ angular.module('DebugEditorApp', [
   # Watch $scope.story
   $scope.$watch('story', ->
       if $scope.story
-        StoryStorage.save_story($scope.story)
-        $scope.graph = DebugParser.compile_graph($scope.story.nodes)
+        storyStorage.save_story($scope.story)
+        $scope.graph = debugParser.compile_graph($scope.story.nodes)
     , true)
 ])

--- a/app/editor/editor.html
+++ b/app/editor/editor.html
@@ -1,0 +1,83 @@
+<div class="container">
+
+  <h1>Yarn Debug Editor</h1>
+  <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
+
+  <div>
+    <h2>Choose a story:</h2>
+    <select class="form-control" required
+      ng-options="_story.title for (id, _story) in stories" ng-model="story">
+    </select>
+  </div>
+
+  <br/>
+
+  <div>
+    <button type="button" class="btn btn-primary"
+      ng-click="new_story()">
+      New Story
+    </button>
+    <button type="button" class="btn btn-primary"
+      ng-click="clear_stories()">
+      Clear Stories
+    </button>
+  </div>
+
+  <hr/>
+
+  <div>
+    <h2>
+      Editing story:
+      <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
+        {{ story.title }}
+      </a>
+    </h2>
+
+    <div>
+      <button type="button" class="btn btn-primary"
+        ng-click="launch_story()">
+        Play
+      </button>
+    </div>
+
+    <br/>
+
+    <div>
+      <form>
+        <div class="form-group">
+          <input class="form-control" placeholder="Node title" ng-model="new_node.node_id" required/>
+        </div>
+        <div class="form-group">
+          <textarea class="form-control" placeholder="Node text" ng-model="new_node.text"></textarea>
+        </div>
+        <input type="submit" class="btn btn-primary" value="Add A Node"
+        ng-click="add_node_to_story(new_node.node_id, new_node.text)" ng-disabled="!new_node.node_id"/>
+      </form>
+    </div>
+
+    <hr/>
+
+    <div ng-repeat="(node_id, text) in story.nodes">
+
+      <h2>Edit story nodes:</h2>
+
+      <div>
+        <h3>
+          <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
+            {{ node_id }}
+          </a>
+        </h3>
+        <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="story.update_node_text(node_id, $data)">
+          <pre>{{ text }}</pre>
+        </a>
+      </div>
+
+      <div ng-repeat="edge in graph.edges_by_node(node_id)">
+        Edges:
+        <a href="#{{ edge.destination }}">{{ edge.destination }}</a>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/app/editor/editor.html
+++ b/app/editor/editor.html
@@ -29,7 +29,7 @@
   <div ng-show="story">
     <h2>
       Editing story:
-      <a name="{{ story.title }}" editable-text="story.title" onbeforesave="x_edit(story.update_title, $data)">
+      <a name="{{ story.title }}" editable-text="story.title" onbeforesave="x_edit(story.set_title, $data)">
         {{ story.title }}
       </a>
     </h2>

--- a/app/editor/editor.html
+++ b/app/editor/editor.html
@@ -29,7 +29,7 @@
   <div ng-show="story">
     <h2>
       Editing story:
-      <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
+      <a name="{{ story.title }}" editable-text="story.title" onbeforesave="x_edit(story.update_title, $data)">
         {{ story.title }}
       </a>
     </h2>
@@ -64,11 +64,11 @@
 
       <div>
         <h3>
-          <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
+          <a name="{{ node_id }}" editable-text="node_id" onbeforesave="x_edit(story.update_node_id, node_id, $data)">
             {{ node_id }}
           </a>
         </h3>
-        <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="story.update_node_text(node_id, $data)">
+        <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="x_edit(story.update_node_text, node_id, $data)">
           <pre>{{ text }}</pre>
         </a>
       </div>

--- a/app/editor/editor.html
+++ b/app/editor/editor.html
@@ -3,10 +3,11 @@
   <h1>Yarn Debug Editor</h1>
   <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
 
-  <div>
+  <div ng-show="has_stories()">
     <h2>Choose a story:</h2>
     <select class="form-control" required
-      ng-options="_story.title for (id, _story) in stories" ng-model="story">
+      ng-options="_story.title for (id, _story) in stories" ng-model="story" ng-change="go_to_story()">
+      <option value="" disabled>Choose a story</option>
     </select>
   </div>
 
@@ -18,14 +19,14 @@
       New Story
     </button>
     <button type="button" class="btn btn-primary"
-      ng-click="clear_stories()">
+      ng-click="clear_stories()" ng-if="has_stories()">
       Clear Stories
     </button>
   </div>
 
   <hr/>
 
-  <div>
+  <div ng-show="story">
     <h2>
       Editing story:
       <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
@@ -43,7 +44,7 @@
     <br/>
 
     <div>
-      <form>
+      <form name="nodeForm">
         <div class="form-group">
           <input class="form-control" placeholder="Node title" ng-model="new_node.node_id" required/>
         </div>

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -5,27 +5,41 @@ describe 'DebugEditorApp', ->
 
   describe 'DebugEditorCtrl', ->
 
+    stories = undefined
+    story1 = undefined
+    story2 = undefined
     $scope = undefined
-    DebugParser = undefined
-    localStorage = undefined
     $window = undefined
+    $routeParams = undefined
+    $location = undefined
+    DebugParser = undefined
+    DebugStoryStorage = undefined
     setUpDebugEditorCtrl = undefined
 
     beforeEach ->
+      stories = {}
+      story1 = new DebugStory()
+      story2 = new DebugStory()
+      stories[story1.id] = story1
+      stories[story2.id] = story2
+
+      # Mock $routeParams, $location. $window
+      $routeParams = {id: story1.id}
+      $location = jasmine.createSpyObj('$location', ['path'])
+      $window = jasmine.createSpyObj('$window', ['open'])
+
       # Mock DebugParser
-      DebugParser = jasmine.createSpyObj('DebugParser', ['compile_graph', 'compile_page'])
+      DebugParser = jasmine.createSpyObj('DebugParser', ['compile_graph'])
       DebugParser.compile_graph.and.callFake((nodes) ->
         return new Yarn.Graph(nodes, [])
       )
-      DebugParser.compile_page.and.callFake((nodes) ->
-        return '<code>' + JSON.stringify(nodes) + '</code>'
+
+      # Mock DebugStoryStorage
+      DebugStoryStorage = jasmine.createSpyObj('DebugStoryStorage', ['clear', 'stories', 'save_story'])
+      DebugStoryStorage.stories.and.callFake(() ->
+        return stories
       )
-      # Mock localStorage
-      localStorage = new MockLocalStorage()
-
-      # Mock $window
-      $window = jasmine.createSpyObj('$window', ['open'])
-
+      
       # setUp method to make DebugEditorCtrl's $scope available for testing
       setUpDebugEditorCtrl = ->
         inject(($rootScope, $controller, _) ->
@@ -34,112 +48,116 @@ describe 'DebugEditorApp', ->
           $controller('DebugEditorCtrl', {
             $scope: $scope,
             $window: $window,
+            $routeParams: $routeParams,
+            $location: $location,
             _: _,
             DebugParser: DebugParser,
-            localStorage: localStorage
+            DebugStory: DebugStory,
+            DebugStoryStorage: DebugStoryStorage
           })
-      )
+        )
 
-    describe 'if yarnNodes key is set in localStorage', ->
-      TEST_NODES = {test_node: 'test'}
-
-      beforeEach ->
-        localStorage.setItem('yarnNodes', JSON.stringify(TEST_NODES))
+    describe 'if $routeParams.id is not defined', ->
+      it 'should not set $scope.story', -> 
+        $routeParams = {} 
         setUpDebugEditorCtrl()
+        expect($scope.story).toBeUndefined()
 
-      it 'should initialise $scope.nodes to its value', ->
-        expect($scope.nodes).toEqual(TEST_NODES)
-
-    describe 'if yarnNodes key is not set in localStorage', ->
+    describe 'setting up DebugEditorCtrl', ->
       beforeEach ->
         setUpDebugEditorCtrl()
+        
+      it 'should set $scope.stories by calling DebugStoryStorage.stories', ->
+        expect($scope.stories).toEqual(DebugStoryStorage.stories())
 
-      it 'should initialise $scope.nodes to an empty object', ->
-        expect($scope.nodes).toEqual({})
+      describe 'if $routeParams.id is defined', ->
+        it 'should set $scope.story as expected', ->
+          expect($scope.story).toEqual(story1)
 
-      it 'should define a $scope variable, $scope.graph, to equal result of DebugParser.compile_graph of $scope.nodes', ->
-        expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.nodes)
-        expect($scope.graph.nodes).toEqual($scope.nodes)
+      describe '.go_to_story', ->
+        describe 'if $scope.story is defined', ->
+          it 'should navigate to the url of the current story', ->
+            $scope.go_to_story()
+            expect($location.path).toHaveBeenCalledWith('/stories/' + $scope.story.id)
 
-      it 'should watch $scope.nodes and set $scope.graph to result of DebugParser.compile_graph of $scope.nodes when $scope.nodes change', ->
-        $scope.nodes.test_node = 'test'
-        expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.nodes)
-        expect($scope.graph.nodes).toEqual($scope.nodes)
+        describe 'if $scope.story is not defined', ->
+          it 'should navigate to the base stories url', ->
+            $scope.story = undefined
+            $scope.go_to_story()
+            expect($location.path).toHaveBeenCalledWith('/stories/')
 
-      describe '.update_node_text', ->
-        it 'should update the text of the specified node', ->
-          $scope.nodes.test_node = ''
-          $scope.update_node_text('test_node', 'test')
-          expect($scope.nodes.test_node).toEqual('test')
+      describe '.add_node_to_story', ->
+        new_node = undefined
 
-      describe '.update_node_id', ->
-        describe 'if a node with the new node_id does not exist', ->
-          it 'should update the node_id of the specified node', ->
-            $scope.nodes.test_node = 'test'
-            $scope.update_node_id('test_node', 'my_test_node')
-            expect($scope.nodes.test_node).toBeUndefined()
-            expect($scope.nodes.my_test_node).toEqual('test')
-
-        describe 'if a node with the new node_id exists', ->
-          result = undefined
-
-          beforeEach ->
-            $scope.nodes = {test_node: 'test', test_node_2: 'test2'}
-            result = $scope.update_node_id('test_node_2', 'test_node')
-
-          it 'should return a string (error string for x-editable)', ->
-            expect(result).toEqual(jasmine.any(String))
-
-          it 'should not update the node_id of the specified node', ->
-            expect($scope.nodes.test_node).toEqual('test')
-            expect($scope.nodes.test_node_2).toEqual('test2')
-
-      describe '.add_node', ->
-        describe 'if a node with the node_id of the new node does not exist', ->
-          it 'should add a new node', ->
-            expect($scope.nodes.test_node).toBeUndefined()
-            $scope.add_node('test_node', 'test')
-            expect($scope.nodes.test_node).toEqual('test')
-
-        describe 'if a node with the node_id of the new node exists', ->
-          beforeEach ->
-            $scope.nodes = {test_node: 'test'}
-            spyOn(window, 'alert')
-            $scope.add_node('test_node', 'test2')
-
-          it 'should not add a new node', ->
-            expect(Object.keys($scope.nodes).length).toEqual(1)
-
-          it 'should not alter the node text of the pre-existing node', ->
-            expect($scope.nodes.test_node).toEqual('test')
-
-          it 'should pop up an alert', ->
-            expect(window.alert).toHaveBeenCalled()
-
-      describe '.save_story', ->
         beforeEach ->
-          $scope.nodes = {test_node: 'test'}
-          $scope.save_story()
+          new_node = {id: 'Test Node', text: 'Test text'}
+          $scope.new_node = new_node 
 
-        it 'should save $scope.nodes to key yarnNodes in localStorage', ->
-          expect(localStorage.getItem('yarnNodes')).toEqual(JSON.stringify($scope.nodes))
+        it 'should call $scope.story.add_node', ->
+          spyOn($scope.story, 'add_node').and.returnValue(false)
+          $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+          expect($scope.story.add_node).toHaveBeenCalledWith($scope.new_node.id, $scope.new_node.text)
 
-        it 'should save compiled story, yarnStory, to localStorage', ->
-          expect(localStorage.getItem('yarnStory')).toEqual(DebugParser.compile_page($scope.nodes))
+        describe 'if $scope.story.add_node returns false', ->
+          it 'should not set $scope.new_node to an empty object', ->
+            spyOn($scope.story, 'add_node').and.returnValue(false)
+            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+            expect($scope.new_node).toEqual(new_node)
+
+        describe 'if $scope.story.add_node returns true', ->
+          beforeEach ->
+            spyOn($scope.story, 'add_node').and.returnValue(true)
+            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+
+          it 'should set $scope.new_node to an empty object', ->
+            expect($scope.new_node).toEqual({})
 
       describe '.launch_story', ->
-        beforeEach ->
-          spyOn($scope, 'save_story')
-          $scope.launch_story()
-
-        it 'should save the current story', ->
-          expect($scope.save_story).toHaveBeenCalled()
-
         it 'should play the story in a new window', ->
-          expect($window.open).toHaveBeenCalledWith('/play.html')
+          $scope.launch_story()
+          expect($window.open).toHaveBeenCalledWith('/play.html#' + $scope.story.id)
 
       describe '.new_story', ->
-        it 'should reset $scope.nodes', ->
-          $scope.nodes = {test_node: 'test'}
+        beforeEach ->
+          spyOn($scope, 'go_to_story')
           $scope.new_story()
-          expect($scope.nodes).toEqual({})
+
+        it 'should set $scope.story a new DebugStory', ->
+          expect($scope.story).not.toEqual(story1)
+          expect($scope.story).toEqual(jasmine.any(DebugStory))
+
+        it 'should add $scope.story to $scope.stories', ->
+          expect(Object.keys($scope.stories).length).toEqual(3)
+          expect($scope.stories[$scope.story.id]).toEqual($scope.story)
+
+        it 'should call $scope.go_to_story', ->
+          expect($scope.go_to_story).toHaveBeenCalled()
+
+        it 'should compile $scope.graph from $scope.story.nodes', ->
+          expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes) 
+          expect($scope.graph).toEqual(DebugParser.compile_graph())
+
+      describe '.clear_stories', ->
+        beforeEach ->
+          spyOn($scope, 'go_to_story')
+          $scope.clear_stories()
+
+        it 'should set $scope.stories to an empty object', ->
+          expect($scope.stories).toEqual({})
+
+        it 'should set $scope.story to undefined', ->
+          expect($scope.story).toBeUndefined()
+
+        it 'should call $scope.go_to_story', ->
+          expect($scope.go_to_story).toHaveBeenCalled()
+
+        it 'should call DebugStoryStorage#clear', ->
+          expect(DebugStoryStorage.clear).toHaveBeenCalled()
+
+      describe '.has_stories', ->
+        it 'should return true if $scope.stories is not empty', ->
+          expect($scope.has_stories()).toBe(true)
+
+        it 'should return false if $scope.stories is empty', ->
+          $scope.stories = {}
+          expect($scope.has_stories()).toBe(false)

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -12,8 +12,8 @@ describe 'DebugEditorApp', ->
     $window = undefined
     $routeParams = undefined
     $location = undefined
-    DebugParser = undefined
-    StoryStorage = undefined
+    debugParser = undefined
+    storyStorage = undefined
     setUpDebugEditorCtrl = undefined
 
     beforeEach ->
@@ -28,15 +28,15 @@ describe 'DebugEditorApp', ->
       $location = jasmine.createSpyObj('$location', ['path'])
       $window = jasmine.createSpyObj('$window', ['open'])
 
-      # Mock DebugParser
-      DebugParser = jasmine.createSpyObj('DebugParser', ['compile_graph'])
-      DebugParser.compile_graph.and.callFake((nodes) ->
+      # Mock debugParser
+      debugParser = jasmine.createSpyObj('debugParser', ['compile_graph'])
+      debugParser.compile_graph.and.callFake((nodes) ->
         return new Yarn.Graph(nodes, [])
       )
 
-      # Mock StoryStorage
-      StoryStorage = jasmine.createSpyObj('StoryStorage', ['clear', 'stories', 'save_story'])
-      StoryStorage.stories.and.callFake(() ->
+      # Mock storyStorage
+      storyStorage = jasmine.createSpyObj('storyStorage', ['clear', 'stories', 'save_story'])
+      storyStorage.stories.and.callFake(() ->
         return stories
       )
       
@@ -51,9 +51,9 @@ describe 'DebugEditorApp', ->
             $routeParams: $routeParams,
             $location: $location,
             _: _,
-            DebugParser: DebugParser,
+            debugParser: debugParser,
             Story: Story,
-            StoryStorage: StoryStorage
+            storyStorage: storyStorage
           })
         )
 
@@ -67,8 +67,8 @@ describe 'DebugEditorApp', ->
       beforeEach ->
         setUpDebugEditorCtrl()
         
-      it 'should set $scope.stories by calling StoryStorage.stories', ->
-        expect($scope.stories).toEqual(StoryStorage.stories())
+      it 'should set $scope.stories by calling storyStorage.stories', ->
+        expect($scope.stories).toEqual(storyStorage.stories())
 
       describe 'if $routeParams.id is defined', ->
         it 'should set $scope.story as expected', ->
@@ -140,8 +140,8 @@ describe 'DebugEditorApp', ->
           expect($scope.go_to_story).toHaveBeenCalled()
 
         it 'should compile $scope.graph from $scope.story.nodes', ->
-          expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
-          expect($scope.graph).toEqual(DebugParser.compile_graph())
+          expect(debugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
+          expect($scope.graph).toEqual(debugParser.compile_graph())
 
       describe '.clear_stories', ->
         beforeEach ->
@@ -157,8 +157,8 @@ describe 'DebugEditorApp', ->
         it 'should call $scope.go_to_story', ->
           expect($scope.go_to_story).toHaveBeenCalled()
 
-        it 'should call StoryStorage#clear', ->
-          expect(StoryStorage.clear).toHaveBeenCalled()
+        it 'should call storyStorage#clear', ->
+          expect(storyStorage.clear).toHaveBeenCalled()
 
       describe '.has_stories', ->
         it 'should return true if $scope.stories is not empty', ->
@@ -173,20 +173,20 @@ describe 'DebugEditorApp', ->
           beforeEach ->
             $scope.$apply()
 
-          it 'should call StoryStorage#save_story', ->
-            expect(StoryStorage.save_story).toHaveBeenCalledWith($scope.story)
+          it 'should call storyStorage#save_story', ->
+            expect(storyStorage.save_story).toHaveBeenCalledWith($scope.story)
 
           it 'should compile $scope.graph from $scope.story.nodes', ->
-            expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
-            expect($scope.graph).toEqual(DebugParser.compile_graph())
+            expect(debugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
+            expect($scope.graph).toEqual(debugParser.compile_graph())
 
         describe 'if $scope.story is not defined', ->
           beforeEach ->
             $scope.story = undefined
             $scope.$apply()
 
-          it 'should not call StoryStorage#save_story', ->
-            expect(StoryStorage.save_story).not.toHaveBeenCalled()
+          it 'should not call storyStorage#save_story', ->
+            expect(storyStorage.save_story).not.toHaveBeenCalled()
 
           it 'should compile $scope.graph from $scope.story.nodes', ->
-            expect(DebugParser.compile_graph).not.toHaveBeenCalled()
+            expect(debugParser.compile_graph).not.toHaveBeenCalled()

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -39,7 +39,7 @@ describe 'DebugEditorApp', ->
       storyStorage.stories.and.callFake(() ->
         return stories
       )
-      
+
       # setUp method to make DebugEditorCtrl's $scope available for testing
       setUpDebugEditorCtrl = ->
         inject(($rootScope, $controller, _) ->
@@ -58,15 +58,15 @@ describe 'DebugEditorApp', ->
         )
 
     describe 'if $routeParams.id is not defined', ->
-      it 'should not set $scope.story', -> 
-        $routeParams = {} 
+      it 'should not set $scope.story', ->
+        $routeParams = {}
         setUpDebugEditorCtrl()
         expect($scope.story).toBeUndefined()
 
     describe 'setting up DebugEditorCtrl', ->
       beforeEach ->
         setUpDebugEditorCtrl()
-        
+
       it 'should set $scope.stories by calling storyStorage.stories', ->
         expect($scope.stories).toEqual(storyStorage.stories())
 
@@ -91,7 +91,7 @@ describe 'DebugEditorApp', ->
 
         beforeEach ->
           new_node = {id: 'Test Node', text: 'Test text'}
-          $scope.new_node = new_node 
+          $scope.new_node = new_node
 
         it 'should call $scope.story.add_node', ->
           spyOn($scope.story, 'add_node')
@@ -167,6 +167,28 @@ describe 'DebugEditorApp', ->
         it 'should return false if $scope.stories is empty', ->
           $scope.stories = {}
           expect($scope.has_stories()).toBe(false)
+
+      describe '.x_edit', ->
+        callback = undefined
+
+        describe 'if an error is not thrown', ->
+          result = undefined
+
+          beforeEach ->
+            callback = jasmine.createSpy()
+            result = $scope.x_edit(callback, false, 'test')
+
+          it 'should call the passed callback with all passed args', ->
+            expect(callback).toHaveBeenCalledWith(false, 'test')
+
+          it 'should return true', ->
+            expect(result).toBe(true)
+
+        describe 'if an error is thrown', ->
+          it 'should catch it and return the error message string', ->
+            callback = jasmine.createSpy().and.throwError('error')
+            result = $scope.x_edit(callback, true)
+            expect(result).toEqual('Error: error')
 
       describe 'watches $scope.story', ->
         describe 'if $scope.story is defined', ->

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -13,13 +13,13 @@ describe 'DebugEditorApp', ->
     $routeParams = undefined
     $location = undefined
     DebugParser = undefined
-    DebugStoryStorage = undefined
+    StoryStorage = undefined
     setUpDebugEditorCtrl = undefined
 
     beforeEach ->
       stories = {}
-      story1 = new DebugStory()
-      story2 = new DebugStory()
+      story1 = new Story()
+      story2 = new Story()
       stories[story1.id] = story1
       stories[story2.id] = story2
 
@@ -34,9 +34,9 @@ describe 'DebugEditorApp', ->
         return new Yarn.Graph(nodes, [])
       )
 
-      # Mock DebugStoryStorage
-      DebugStoryStorage = jasmine.createSpyObj('DebugStoryStorage', ['clear', 'stories', 'save_story'])
-      DebugStoryStorage.stories.and.callFake(() ->
+      # Mock StoryStorage
+      StoryStorage = jasmine.createSpyObj('StoryStorage', ['clear', 'stories', 'save_story'])
+      StoryStorage.stories.and.callFake(() ->
         return stories
       )
       
@@ -52,8 +52,8 @@ describe 'DebugEditorApp', ->
             $location: $location,
             _: _,
             DebugParser: DebugParser,
-            DebugStory: DebugStory,
-            DebugStoryStorage: DebugStoryStorage
+            Story: Story,
+            StoryStorage: StoryStorage
           })
         )
 
@@ -67,8 +67,8 @@ describe 'DebugEditorApp', ->
       beforeEach ->
         setUpDebugEditorCtrl()
         
-      it 'should set $scope.stories by calling DebugStoryStorage.stories', ->
-        expect($scope.stories).toEqual(DebugStoryStorage.stories())
+      it 'should set $scope.stories by calling StoryStorage.stories', ->
+        expect($scope.stories).toEqual(StoryStorage.stories())
 
       describe 'if $routeParams.id is defined', ->
         it 'should set $scope.story as expected', ->
@@ -128,9 +128,9 @@ describe 'DebugEditorApp', ->
           spyOn($scope, 'go_to_story')
           $scope.new_story()
 
-        it 'should set $scope.story a new DebugStory', ->
+        it 'should set $scope.story a new Story', ->
           expect($scope.story).not.toEqual(story1)
-          expect($scope.story).toEqual(jasmine.any(DebugStory))
+          expect($scope.story).toEqual(jasmine.any(Story))
 
         it 'should add $scope.story to $scope.stories', ->
           expect(Object.keys($scope.stories).length).toEqual(3)
@@ -157,8 +157,8 @@ describe 'DebugEditorApp', ->
         it 'should call $scope.go_to_story', ->
           expect($scope.go_to_story).toHaveBeenCalled()
 
-        it 'should call DebugStoryStorage#clear', ->
-          expect(DebugStoryStorage.clear).toHaveBeenCalled()
+        it 'should call StoryStorage#clear', ->
+          expect(StoryStorage.clear).toHaveBeenCalled()
 
       describe '.has_stories', ->
         it 'should return true if $scope.stories is not empty', ->
@@ -173,8 +173,8 @@ describe 'DebugEditorApp', ->
           beforeEach ->
             $scope.$apply()
 
-          it 'should call DebugStoryStorage#save_story', ->
-            expect(DebugStoryStorage.save_story).toHaveBeenCalledWith($scope.story)
+          it 'should call StoryStorage#save_story', ->
+            expect(StoryStorage.save_story).toHaveBeenCalledWith($scope.story)
 
           it 'should compile $scope.graph from $scope.story.nodes', ->
             expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
@@ -185,8 +185,8 @@ describe 'DebugEditorApp', ->
             $scope.story = undefined
             $scope.$apply()
 
-          it 'should not call DebugStoryStorage#save_story', ->
-            expect(DebugStoryStorage.save_story).not.toHaveBeenCalled()
+          it 'should not call StoryStorage#save_story', ->
+            expect(StoryStorage.save_story).not.toHaveBeenCalled()
 
           it 'should compile $scope.graph from $scope.story.nodes', ->
             expect(DebugParser.compile_graph).not.toHaveBeenCalled()

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -134,7 +134,7 @@ describe 'DebugEditorApp', ->
           expect($scope.go_to_story).toHaveBeenCalled()
 
         it 'should compile $scope.graph from $scope.story.nodes', ->
-          expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes) 
+          expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
           expect($scope.graph).toEqual(DebugParser.compile_graph())
 
       describe '.clear_stories', ->
@@ -161,3 +161,26 @@ describe 'DebugEditorApp', ->
         it 'should return false if $scope.stories is empty', ->
           $scope.stories = {}
           expect($scope.has_stories()).toBe(false)
+
+      describe 'watches $scope.story', ->
+        describe 'if $scope.story is defined', ->
+          beforeEach ->
+            $scope.$apply()
+
+          it 'should call DebugStoryStorage#save_story', ->
+            expect(DebugStoryStorage.save_story).toHaveBeenCalledWith($scope.story)
+
+          it 'should compile $scope.graph from $scope.story.nodes', ->
+            expect(DebugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
+            expect($scope.graph).toEqual(DebugParser.compile_graph())
+
+        describe 'if $scope.story is not defined', ->
+          beforeEach ->
+            $scope.story = undefined
+            $scope.$apply()
+
+          it 'should not call DebugStoryStorage#save_story', ->
+            expect(DebugStoryStorage.save_story).not.toHaveBeenCalled()
+
+          it 'should compile $scope.graph from $scope.story.nodes', ->
+            expect(DebugParser.compile_graph).not.toHaveBeenCalled()

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -94,19 +94,25 @@ describe 'DebugEditorApp', ->
           $scope.new_node = new_node 
 
         it 'should call $scope.story.add_node', ->
-          spyOn($scope.story, 'add_node').and.returnValue(false)
+          spyOn($scope.story, 'add_node')
           $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
-          expect($scope.story.add_node).toHaveBeenCalledWith($scope.new_node.id, $scope.new_node.text)
+          expect($scope.story.add_node).toHaveBeenCalledWith(new_node.id, new_node.text)
 
-        describe 'if $scope.story.add_node returns false', ->
-          it 'should not set $scope.new_node to an empty object', ->
-            spyOn($scope.story, 'add_node').and.returnValue(false)
+        describe 'if $scope.story.add_node throws an error', ->
+          beforeEach ->
+            spyOn(window, 'alert')
+            spyOn($scope.story, 'add_node').and.callFake(-> throw "Error")
             $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+
+          it 'should not set $scope.new_node to an empty object', ->
             expect($scope.new_node).toEqual(new_node)
+
+          it 'should pop open an alert', ->
+            expect(window.alert).toHaveBeenCalled()
 
         describe 'if $scope.story.add_node returns true', ->
           beforeEach ->
-            spyOn($scope.story, 'add_node').and.returnValue(true)
+            spyOn($scope.story, 'add_node')
             $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
 
           it 'should set $scope.new_node to an empty object', ->

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -1,0 +1,61 @@
+DebugParser = new window.Yarn.DebugParser()
+
+class DebugStory
+  constructor: (@id = 'yarn-' + _.uuid(), @nodes = {}) ->
+
+  _contains: (node_id) ->
+    return _.contains(_.keys(@nodes), node_id)
+
+  add_node: (node_id, text) ->
+    if @_contains(node_id)
+      alert('Node with this title already exists.')
+      return false
+    @nodes[node_id] = text
+    return true
+
+  update_node_text: (node_id, node_text) ->
+    @nodes[node_id] = node_text
+    return true
+
+  update_node_id: (node_id, new_node_id) ->
+    if node_id == new_node_id
+      return true
+    if @_contains(new_node_id)
+      return 'Node with this title already exists.'
+    @nodes[new_node_id] = @nodes[node_id]
+    delete @nodes[node_id]
+    return true
+
+  to_json: () ->
+   return {nodes: @nodes}
+
+  @from_json: (id, json_object) ->
+    return new DebugStory(id, json_object.nodes)
+
+
+class StoryStorage
+  constructor: (@storage) ->
+
+  load_story: (id) ->
+    try
+      json_object = JSON.parse(@storage.getItem(id))
+    catch error
+      json_object = undefined
+      console.log('Error deserializing nodes from localStorage: ' + error)
+    return DebugStory.from_json(id, json_object)
+
+  save_story: (story) ->
+    @storage.setItem(story.id, JSON.stringify(story.to_json()))
+    @storage.setItem(story.id + '-story', DebugParser.compile_page(story.nodes))
+
+  story_ids: ->
+    return _.filter _.keys(@storage), (key) ->
+      return _.startsWith(key, 'yarn-') && !_.endsWith(key, '-story') && !_.endsWith(key, 'story-id')
+
+  clear: ->
+    for key in _.keys(@storage)
+      @storage.removeItem(key) if _.startsWith(key, 'yarn-')
+
+
+window.DebugStory = DebugStory
+window.StoryStorage = StoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -65,11 +65,10 @@ class DebugStoryStorage
 
   _load_story: (id) ->
     try
-      json_object = JSON.parse(@storage.getItem(id))
+      return DebugStory.from_json(id,
+        JSON.parse(@storage.getItem(id)))
     catch error
-      json_object = undefined
-      console.log('Error deserializing nodes from localStorage: ' + error)
-    return DebugStory.from_json(id, json_object)
+      throw "Error parsing story with id=#{id}: #{error}\n"
 
 window.DebugStory = DebugStory
 window.DebugStoryStorage = DebugStoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -49,6 +49,7 @@ class DebugStoryStorage
       @storage.removeItem(key) if _.startsWith(key, 'yarn-')
 
   save_story: (story) ->
+    @storage.setItem('yarn-story-id', story.id)
     @storage.setItem(story.id, JSON.stringify(story.to_json()))
     @storage.setItem(story.id + '-story', DebugParser.compile_page(story.nodes))
 

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -12,8 +12,7 @@ class Story
   to_json: () =>
    return {title: @title, nodes: @nodes}
 
-  update_title: (title) =>
-    @title = title
+  set_title: (@title) =>
 
   update_node_id: (node_id, new_node_id) =>
     if @_contains(new_node_id) && node_id != new_node_id
@@ -37,8 +36,6 @@ class Story
   # Class Methods
   @from_json: (id, json_object) ->
     return new Story(id, json_object.title, json_object.nodes)
-
-
 
 class StoryStorage
   constructor: (@storage, @parser) ->

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -1,6 +1,6 @@
 DebugParser = new window.Yarn.DebugParser()
 
-class DebugStory
+class Story
   constructor: (@id = 'yarn-' + _.uuid(), @title = 'My New Story', @nodes = {}) ->
 
   # Public Methods
@@ -35,11 +35,11 @@ class DebugStory
 
   # Class Methods
   @from_json: (id, json_object) ->
-    return new DebugStory(id, json_object.title, json_object.nodes)
+    return new Story(id, json_object.title, json_object.nodes)
 
 
 
-class DebugStoryStorage
+class StoryStorage
   constructor: (@storage, @parser) ->
 
   # Public Methods
@@ -64,10 +64,10 @@ class DebugStoryStorage
 
   _load_story: (id) ->
     try
-      return DebugStory.from_json(id,
+      return Story.from_json(id,
         JSON.parse(@storage.getItem(id)))
     catch error
       throw "Error parsing story with id=#{id}: #{error}\n"
 
-window.DebugStory = DebugStory
-window.DebugStoryStorage = DebugStoryStorage
+window.Story = Story
+window.StoryStorage = StoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -1,7 +1,7 @@
 DebugParser = new window.Yarn.DebugParser()
 
 class DebugStory
-  constructor: (@id = 'yarn-' + _.uuid(), @title = 'New Story', @nodes = {}) ->
+  constructor: (@id = 'yarn-' + _.uuid(), @title = 'My New Story', @nodes = {}) ->
 
   _contains: (node_id) ->
     return _.contains(_.keys(@nodes), node_id)
@@ -15,6 +15,7 @@ class DebugStory
 
   update_title: (title) ->
     @title = title
+    return true
 
   update_node_text: (node_id, node_text) ->
     @nodes[node_id] = node_text

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -6,10 +6,8 @@ class DebugStory
   # Public Methods
   add_node: (node_id, text) ->
     if @_contains(node_id)
-      alert('Node with this title already exists.')
-      return false
+      throw "Node with title #{node_id} already exists."
     @nodes[node_id] = text
-    return true
 
   to_json: () ->
    return {title: @title, nodes: @nodes}
@@ -38,6 +36,7 @@ class DebugStory
   # Class Methods
   @from_json: (id, json_object) ->
     return new DebugStory(id, json_object.title, json_object.nodes)
+
 
 
 class DebugStoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -16,6 +16,8 @@ class Story
     @title = title
     return true
 
+  # Returns true if success, a string otherwise
+  # This is required by angular-xeditable's success & error handling
   update_node_id: (node_id, new_node_id) ->
     if node_id == new_node_id
       return true

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -41,7 +41,7 @@ class DebugStory
 
 
 class DebugStoryStorage
-  constructor: (@storage) ->
+  constructor: (@storage, @parser) ->
 
   # Public Methods
   clear: ->
@@ -50,7 +50,7 @@ class DebugStoryStorage
 
   save_story: (story) ->
     @storage.setItem(story.id, JSON.stringify(story.to_json()))
-    @storage.setItem(story.id + '-story', DebugParser.compile_page(story.nodes))
+    @storage.setItem(story.id + '-story', @parser.compile_page(story.nodes))
 
   stories: ->
     stories = {}

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -4,32 +4,26 @@ class Story
   constructor: (@id = 'yarn-' + _.uuid(), @title = 'My New Story', @nodes = {}) ->
 
   # Public Methods
-  add_node: (node_id, text) ->
+  add_node: (node_id, text) =>
     if @_contains(node_id)
       throw "Node with title #{node_id} already exists."
     @nodes[node_id] = text
 
-  to_json: () ->
+  to_json: () =>
    return {title: @title, nodes: @nodes}
 
-  update_title: (title) ->
+  update_title: (title) =>
     @title = title
-    return true
 
-  # Returns true if success, a string otherwise
-  # This is required by angular-xeditable's success & error handling
-  update_node_id: (node_id, new_node_id) ->
-    if node_id == new_node_id
-      return true
-    if @_contains(new_node_id)
-      return 'Node with this title already exists.'
-    @nodes[new_node_id] = @nodes[node_id]
-    delete @nodes[node_id]
-    return true
+  update_node_id: (node_id, new_node_id) =>
+    if @_contains(new_node_id) && node_id != new_node_id
+      throw "Node with title #{node_id} already exists."
+    unless node_id == new_node_id
+      @nodes[new_node_id] = @nodes[node_id]
+      delete @nodes[node_id]
 
-  update_node_text: (node_id, node_text) ->
+  update_node_text: (node_id, node_text) =>
     @nodes[node_id] = node_text
-    return true
 
   # Private Methods
   _contains: (node_id) ->

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -49,7 +49,6 @@ class DebugStoryStorage
       @storage.removeItem(key) if _.startsWith(key, 'yarn-')
 
   save_story: (story) ->
-    @storage.setItem('yarn-story-id', story.id)
     @storage.setItem(story.id, JSON.stringify(story.to_json()))
     @storage.setItem(story.id + '-story', DebugParser.compile_page(story.nodes))
 
@@ -62,7 +61,7 @@ class DebugStoryStorage
   # Private Methods
   _story_ids: ->
     return _.filter _.keys(@storage), (key) ->
-      return _.startsWith(key, 'yarn-') && !_.endsWith(key, '-story') && !_.endsWith(key, 'story-id')
+      return _.startsWith(key, 'yarn-') && !_.endsWith(key, '-story')
 
   _load_story: (id) ->
     try

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -1,7 +1,7 @@
 DebugParser = new window.Yarn.DebugParser()
 
 class DebugStory
-  constructor: (@id = 'yarn-' + _.uuid(), @nodes = {}) ->
+  constructor: (@id = 'yarn-' + _.uuid(), @title = 'New Story', @nodes = {}) ->
 
   _contains: (node_id) ->
     return _.contains(_.keys(@nodes), node_id)
@@ -12,6 +12,9 @@ class DebugStory
       return false
     @nodes[node_id] = text
     return true
+
+  update_title: (title) ->
+    @title = title
 
   update_node_text: (node_id, node_text) ->
     @nodes[node_id] = node_text
@@ -27,10 +30,10 @@ class DebugStory
     return true
 
   to_json: () ->
-   return {nodes: @nodes}
+   return {title: @title, nodes: @nodes}
 
   @from_json: (id, json_object) ->
-    return new DebugStory(id, json_object.nodes)
+    return new DebugStory(id, json_object.title, json_object.nodes)
 
 
 class StoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -40,7 +40,7 @@ class DebugStory
     return new DebugStory(id, json_object.title, json_object.nodes)
 
 
-class StoryStorage
+class DebugStoryStorage
   constructor: (@storage) ->
 
   # Public Methods
@@ -72,4 +72,4 @@ class StoryStorage
     return DebugStory.from_json(id, json_object)
 
 window.DebugStory = DebugStory
-window.StoryStorage = StoryStorage
+window.DebugStoryStorage = DebugStoryStorage

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -24,11 +24,6 @@ class Story
   update_node_text: (node_id, node_text) =>
     @nodes[node_id] = node_text
 
-  equals: (other_story) ->
-    result = other_story instanceof Story
-    result = result && @id == other_story.id && @title == other_story.title
-    return result && _.isEqual(@nodes, other_story.nodes)
-
   # Private Methods
   _contains: (node_id) ->
     return _.contains(_.keys(@nodes), node_id)

--- a/app/editor/story.coffee
+++ b/app/editor/story.coffee
@@ -25,6 +25,11 @@ class Story
   update_node_text: (node_id, node_text) =>
     @nodes[node_id] = node_text
 
+  equals: (other_story) ->
+    result = other_story instanceof Story
+    result = result && @id == other_story.id && @title == other_story.title
+    return result && _.isEqual(@nodes, other_story.nodes)
+
   # Private Methods
   _contains: (node_id) ->
     return _.contains(_.keys(@nodes), node_id)

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -1,143 +1,125 @@
-describe 'Story', ->
+describe 'Story and StoryStorage', ->
 
-  story = undefined
-
-  beforeEach ->
-    story = new Story()
-
-  describe '#add_node', ->
-    describe 'if a node with the node_id of the new node does not exist', ->
-      it 'should add a new node', ->
-        expect(story.nodes.test_node).toBeUndefined()
-        story.add_node('test_node', 'test')
-        expect(story.nodes.test_node).toEqual('test')
-
-    describe 'if a node with the node_id of the new node exists', ->
-      it 'should throw an error, and leave nodes unchanged', ->
-        story.nodes = {test_node: 'test'}
-        expect(-> story.add_node('test_node', 'test2')).toThrow()
-        expect(Object.keys(story.nodes).length).toEqual(1)
-        expect(story.nodes.test_node).toEqual('test')
-
-  describe '#to_json', ->
-    it 'should return plain javascript object in expected format', ->
-      story.title = 'Test Story'
-      story.nodes = {test_node: 'test', test_node_2: 'test2'}
-      expect(story.to_json()).toEqual({title: story.title, nodes: story.nodes})
-
-  describe '#set_title', ->
-    it 'should set the story\'s title to the specified value', ->
-      story.set_title('Test title')
-      expect(story.title).toEqual('Test title')
-
-  describe '#update_node_id', ->
-    describe 'if a node with the new node_id does not exist', ->
-      it 'should update the node_id of the specified node', ->
-        story.nodes.test_node = 'test'
-        story.update_node_id('test_node', 'my_test_node')
-        expect(story.nodes.test_node).toBeUndefined()
-        expect(story.nodes.my_test_node).toEqual('test')
-
-    describe 'if a node with the new node_id exists', ->
-      beforeEach ->
-        story.nodes = {test_node: 'test', test_node_2: 'test2'}
-
-      it 'should throw an error and leave nodes unchanged', ->
-        expect(-> story.update_node_id('test_node_2', 'test_node')).toThrow()
-        expect(story.nodes.test_node).toEqual('test')
-        expect(story.nodes.test_node_2).toEqual('test2')
-
-  describe '#update_node_text', ->
-    it 'should update the text of the specified node', ->
-      story.nodes.test_node = ''
-      story.update_node_text('test_node', 'test')
-      expect(story.nodes.test_node).toEqual('test')
-
-  describe 'equals', ->
-    other_story = undefined
-
-    beforeEach ->
-      story.nodes = {test_node: 'test', test_node_2: 'test2'}
-      other_story = new Story(story.id, story.title, story.nodes)
-
-    it 'should return true if story equals other story it is compared to', ->
-      expect(story.equals(other_story)).toBe(true)
-
-    it 'should return false if other story\'s is node of class story', ->
-      other_story = {id: story.id, title: story.title, nodes: story.nodes}
-      expect(story.equals(other_story)).toBe(false)
-
-    it 'should return false if other story\'s title is different', ->
-      other_story.title = 'Cloned title'
-      expect(story.equals(other_story)).toBe(false)
-
-    it 'should return false if other story\'s id is different', ->
-      other_story.id = 'Cloned id'
-      expect(story.equals(other_story)).toBe(false)
-
-    it 'should return false if other story\'s nodes different', ->
-      other_story = _.cloneDeep(story)
-      other_story.nodes = {test_node: 'test2', test_node_2: 'test'}
-      expect(story.equals(other_story)).toBe(false)
-
-
-  describe '.from_json', ->
-    it 'should correctly construct a Story from a story_id and the jsonified story', ->
-      story_from_json = Story.from_json(story.id, story.to_json())
-      expect(story_from_json).toEqual(jasmine.any(Story))
-      expect(story_from_json.equals(story)).toBe(true)
-
-
-describe 'StoryStorage', ->
-
-  story_storage = undefined
-  localStorage = undefined
-  story1 = undefined
-  story2 = undefined
-  DebugParser = undefined
+  stories_are_equal = undefined
 
   beforeEach ->
-    DebugParser = jasmine.createSpyObj('DebugParser', ['compile_page'])
-    DebugParser.compile_page.and.callFake((nodes) ->
-      return '<code>' + JSON.stringify(nodes) + '</code>'
-    )
-    story1 = new Story()
-    story2 = new Story()
-    localStorage = new MockLocalStorage()
-    story_storage = new StoryStorage(localStorage, DebugParser)
-    localStorage.setItem(story1.id, JSON.stringify(story1.to_json()))
-    localStorage.setItem(story2.id, JSON.stringify(story2.to_json()))
+    stories_are_equal = (story, other_story) ->
+      story.id == other_story.id &&
+      story.title == other_story.title &&
+      _.isEqual(story.nodes, other_story.nodes)
 
-  describe '#clear', ->
-    beforeEach ->
-      localStorage.setItem('test', 'test value')
-      story_storage.clear()
+  describe 'Story', ->
 
-    it 'should clear all keys beginning with "yarn-" from storage', ->
-      expect(localStorage.getItem(story1.id)).not.toBeDefined()
-      expect(localStorage.getItem(story2.id)).not.toBeDefined()
-
-    it 'should not clear keys that do not begin with "yarn-" from storage', ->
-      expect(localStorage.getItem('test')).toEqual('test value')
-
-  describe '#save_story', ->
     story = undefined
 
     beforeEach ->
       story = new Story()
-      story_storage.save_story(story)
 
-    it 'should save the serialized story to storage with expected reference key', ->
-      serialized_story = JSON.stringify(story.to_json())
-      expect(localStorage.getItem(story.id)).toEqual(serialized_story)
+    describe '#add_node', ->
+      describe 'if a node with the node_id of the new node does not exist', ->
+        it 'should add a new node', ->
+          expect(story.nodes.test_node).toBeUndefined()
+          story.add_node('test_node', 'test')
+          expect(story.nodes.test_node).toEqual('test')
 
-    it 'should save the compiled story to storage with expected reference key', ->
-      compiled_story = DebugParser.compile_page(story.nodes)
-      expect(localStorage.getItem(story.id + '-story')).toEqual(compiled_story)
+      describe 'if a node with the node_id of the new node exists', ->
+        it 'should throw an error, and leave nodes unchanged', ->
+          story.nodes = {test_node: 'test'}
+          expect(-> story.add_node('test_node', 'test2')).toThrow()
+          expect(Object.keys(story.nodes).length).toEqual(1)
+          expect(story.nodes.test_node).toEqual('test')
 
-  describe '#stories', ->
-    it 'should return an object containing all stories in storage as Story objects, using their ids as keys', ->
-      stories = story_storage.stories()
-      expect(_.keys(stories).length).toEqual(2)
-      expect(stories[story1.id].equals(story1)).toBe(true)
-      expect(stories[story2.id].equals(story2)).toBe(true)
+    describe '#to_json', ->
+      it 'should return plain javascript object in expected format', ->
+        story.title = 'Test Story'
+        story.nodes = {test_node: 'test', test_node_2: 'test2'}
+        expect(story.to_json()).toEqual({title: story.title, nodes: story.nodes})
+
+    describe '#set_title', ->
+      it 'should set the story\'s title to the specified value', ->
+        story.set_title('Test title')
+        expect(story.title).toEqual('Test title')
+
+    describe '#update_node_id', ->
+      describe 'if a node with the new node_id does not exist', ->
+        it 'should update the node_id of the specified node', ->
+          story.nodes.test_node = 'test'
+          story.update_node_id('test_node', 'my_test_node')
+          expect(story.nodes.test_node).toBeUndefined()
+          expect(story.nodes.my_test_node).toEqual('test')
+
+      describe 'if a node with the new node_id exists', ->
+        beforeEach ->
+          story.nodes = {test_node: 'test', test_node_2: 'test2'}
+
+        it 'should throw an error and leave nodes unchanged', ->
+          expect(-> story.update_node_id('test_node_2', 'test_node')).toThrow()
+          expect(story.nodes.test_node).toEqual('test')
+          expect(story.nodes.test_node_2).toEqual('test2')
+
+    describe '#update_node_text', ->
+      it 'should update the text of the specified node', ->
+        story.nodes.test_node = ''
+        story.update_node_text('test_node', 'test')
+        expect(story.nodes.test_node).toEqual('test')
+
+    describe '.from_json', ->
+      it 'should correctly construct a Story from a story_id and the jsonified story', ->
+        story_from_json = Story.from_json(story.id, story.to_json())
+        expect(story_from_json).toEqual(jasmine.any(Story))
+        expect(stories_are_equal(story, story_from_json)).toBe(true)
+
+
+  describe 'StoryStorage', ->
+
+    story_storage = undefined
+    localStorage = undefined
+    story1 = undefined
+    story2 = undefined
+    DebugParser = undefined
+
+    beforeEach ->
+      DebugParser = jasmine.createSpyObj('DebugParser', ['compile_page'])
+      DebugParser.compile_page.and.callFake((nodes) ->
+        return '<code>' + JSON.stringify(nodes) + '</code>'
+      )
+      story1 = new Story()
+      story2 = new Story()
+      localStorage = new MockLocalStorage()
+      story_storage = new StoryStorage(localStorage, DebugParser)
+      localStorage.setItem(story1.id, JSON.stringify(story1.to_json()))
+      localStorage.setItem(story2.id, JSON.stringify(story2.to_json()))
+
+    describe '#clear', ->
+      beforeEach ->
+        localStorage.setItem('test', 'test value')
+        story_storage.clear()
+
+      it 'should clear all keys beginning with "yarn-" from storage', ->
+        expect(localStorage.getItem(story1.id)).not.toBeDefined()
+        expect(localStorage.getItem(story2.id)).not.toBeDefined()
+
+      it 'should not clear keys that do not begin with "yarn-" from storage', ->
+        expect(localStorage.getItem('test')).toEqual('test value')
+
+    describe '#save_story', ->
+      story = undefined
+
+      beforeEach ->
+        story = new Story()
+        story_storage.save_story(story)
+
+      it 'should save the serialized story to storage with expected reference key', ->
+        serialized_story = JSON.stringify(story.to_json())
+        expect(localStorage.getItem(story.id)).toEqual(serialized_story)
+
+      it 'should save the compiled story to storage with expected reference key', ->
+        compiled_story = DebugParser.compile_page(story.nodes)
+        expect(localStorage.getItem(story.id + '-story')).toEqual(compiled_story)
+
+    describe '#stories', ->
+      it 'should return an object containing all stories in storage as Story objects, using their ids as keys', ->
+        stories = story_storage.stories()
+        expect(_.keys(stories).length).toEqual(2)
+        expect(stories_are_equal(stories[story1.id], story1)).toBe(true)
+        expect(stories_are_equal(stories[story2.id], story2)).toBe(true)

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -80,12 +80,17 @@ describe 'DebugStoryStorage', ->
   localStorage = undefined
   story1 = undefined
   story2 = undefined
+  DebugParser = undefined
 
   beforeEach ->
+    DebugParser = jasmine.createSpyObj('DebugParser', ['compile_page'])
+    DebugParser.compile_page.and.callFake((nodes) ->
+      return '<code>' + JSON.stringify(nodes) + '</code>'
+    )
     story1 = new DebugStory()
     story2 = new DebugStory()
     localStorage = new MockLocalStorage()
-    story_storage = new DebugStoryStorage(localStorage)
+    story_storage = new DebugStoryStorage(localStorage, DebugParser)
     localStorage.setItem(story1.id, JSON.stringify(story1.to_json()))
     localStorage.setItem(story2.id, JSON.stringify(story2.to_json()))
 
@@ -113,8 +118,7 @@ describe 'DebugStoryStorage', ->
       expect(localStorage.getItem(story.id)).toEqual(serialized_story)
 
     it 'should save the compiled story to storage with expected reference key', ->
-      parser = new window.Yarn.DebugParser()
-      compiled_story = parser.compile_page(story.nodes)
+      compiled_story = DebugParser.compile_page(story.nodes)
       expect(localStorage.getItem(story.id + '-story')).toEqual(compiled_story)
 
   describe '#stories', ->

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -1,9 +1,9 @@
-describe 'DebugStory', ->
+describe 'Story', ->
 
   story = undefined
 
   beforeEach ->
-    story = new DebugStory()
+    story = new Story()
 
   describe '#add_node', ->
     describe 'if a node with the node_id of the new node does not exist', ->
@@ -60,13 +60,13 @@ describe 'DebugStory', ->
       expect(story.nodes.test_node).toEqual('test')
 
   describe '.from_json', ->
-    it 'should correctly construct a DebugStory from a story_id and the jsonified story', ->
-      story_from_json = DebugStory.from_json(story.id, story.to_json())
-      expect(story_from_json).toEqual(jasmine.any(DebugStory))
+    it 'should correctly construct a Story from a story_id and the jsonified story', ->
+      story_from_json = Story.from_json(story.id, story.to_json())
+      expect(story_from_json).toEqual(jasmine.any(Story))
       expect(_.isEqual(story_from_json, story)).toBe(true)
 
 
-describe 'DebugStoryStorage', ->
+describe 'StoryStorage', ->
 
   story_storage = undefined
   localStorage = undefined
@@ -79,10 +79,10 @@ describe 'DebugStoryStorage', ->
     DebugParser.compile_page.and.callFake((nodes) ->
       return '<code>' + JSON.stringify(nodes) + '</code>'
     )
-    story1 = new DebugStory()
-    story2 = new DebugStory()
+    story1 = new Story()
+    story2 = new Story()
     localStorage = new MockLocalStorage()
-    story_storage = new DebugStoryStorage(localStorage, DebugParser)
+    story_storage = new StoryStorage(localStorage, DebugParser)
     localStorage.setItem(story1.id, JSON.stringify(story1.to_json()))
     localStorage.setItem(story2.id, JSON.stringify(story2.to_json()))
 
@@ -102,7 +102,7 @@ describe 'DebugStoryStorage', ->
     story = undefined
 
     beforeEach ->
-      story = new DebugStory()
+      story = new Story()
       story_storage.save_story(story)
 
     it 'should save the serialized story to storage with expected reference key', ->
@@ -114,7 +114,7 @@ describe 'DebugStoryStorage', ->
       expect(localStorage.getItem(story.id + '-story')).toEqual(compiled_story)
 
   describe '#stories', ->
-    it 'should return an object containing all stories in storage as DebugStory objects, using their ids as keys', ->
+    it 'should return an object containing all stories in storage as Story objects, using their ids as keys', ->
       stories = story_storage.stories()
       expect(_.keys(stories).length).toEqual(2)
       expect(_.isEqual(stories[story1.id], story1)).toBe(true)

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -1,0 +1,85 @@
+describe 'DebugStory', ->
+
+  story = undefined
+
+  beforeEach ->
+    story = new DebugStory()
+
+  describe '#add_node', ->
+    describe 'if a node with the node_id of the new node does not exist', ->
+      it 'should add a new node', ->
+        expect(story.nodes.test_node).toBeUndefined()
+        story.add_node('test_node', 'test')
+        expect(story.nodes.test_node).toEqual('test')
+
+    describe 'if a node with the node_id of the new node exists', ->
+      beforeEach ->
+        story.nodes = {test_node: 'test'}
+        spyOn(window, 'alert')
+        story.add_node('test_node', 'test2')
+
+      it 'should not add a new node', ->
+        expect(Object.keys(story.nodes).length).toEqual(1)
+
+      it 'should not alter the node text of the pre-existing node', ->
+        expect(story.nodes.test_node).toEqual('test')
+
+      it 'should pop up an alert', ->
+        expect(window.alert).toHaveBeenCalled()
+
+  describe '#to_json', ->
+    it 'should return plain javascript object in expected format', ->
+      story.title = 'Test Story'
+      story.nodes = {test_node: 'test', test_node_2: 'test2'}
+      expect(story.to_json()).toEqual({title: story.title, nodes: story.nodes})
+
+  describe '#update_title', ->
+    it 'should update the story\'s title to the specified value', ->
+      story.update_title('Test title')
+      expect(story.title).toEqual('Test title')
+
+  describe '#update_node_id', ->
+    describe 'if a node with the new node_id does not exist', ->
+      it 'should update the node_id of the specified node', ->
+        story.nodes.test_node = 'test'
+        story.update_node_id('test_node', 'my_test_node')
+        expect(story.nodes.test_node).toBeUndefined()
+        expect(story.nodes.my_test_node).toEqual('test')
+
+    describe 'if a node with the new node_id exists', ->
+      result = undefined
+
+      beforeEach ->
+        story.nodes = {test_node: 'test', test_node_2: 'test2'}
+        result = story.update_node_id('test_node_2', 'test_node')
+
+      it 'should return a string (error string for x-editable)', ->
+        expect(result).toEqual(jasmine.any(String))
+
+      it 'should not update the node_id of the specified node', ->
+        expect(story.nodes.test_node).toEqual('test')
+        expect(story.nodes.test_node_2).toEqual('test2')
+
+
+  describe '#update_node_text', ->
+    it 'should update the text of the specified node', ->
+      story.nodes.test_node = ''
+      story.update_node_text('test_node', 'test')
+      expect(story.nodes.test_node).toEqual('test')
+
+  describe '.from_json', ->
+    it 'should correctly construct a DebugStory from a story_id and the jsonified story', ->
+      story_from_json = DebugStory.from_json(story.id, story.to_json())
+      expect(story_from_json).toEqual(jasmine.any(DebugStory))
+      expect(_.isEqual(story_from_json, story)).toBe(true)
+
+
+describe 'DebugStoryStorage', ->
+
+  beforeEach ->
+
+  describe '#clear', ->
+
+  describe '#save_story', ->
+
+  describe '#stories', ->

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -39,19 +39,13 @@ describe 'Story', ->
         expect(story.nodes.my_test_node).toEqual('test')
 
     describe 'if a node with the new node_id exists', ->
-      result = undefined
-
       beforeEach ->
         story.nodes = {test_node: 'test', test_node_2: 'test2'}
-        result = story.update_node_id('test_node_2', 'test_node')
 
-      it 'should return a string (error string for x-editable)', ->
-        expect(result).toEqual(jasmine.any(String))
-
-      it 'should not update the node_id of the specified node', ->
+      it 'should throw an error and leave nodes unchanged', ->
+        expect(-> story.update_node_id('test_node_2', 'test_node')).toThrow()
         expect(story.nodes.test_node).toEqual('test')
         expect(story.nodes.test_node_2).toEqual('test2')
-
 
   describe '#update_node_text', ->
     it 'should update the text of the specified node', ->
@@ -59,11 +53,39 @@ describe 'Story', ->
       story.update_node_text('test_node', 'test')
       expect(story.nodes.test_node).toEqual('test')
 
+  describe 'equals', ->
+    other_story = undefined
+
+    beforeEach ->
+      story.nodes = {test_node: 'test', test_node_2: 'test2'}
+      other_story = new Story(story.id, story.title, story.nodes)
+
+    it 'should return true if story equals other story it is compared to', ->
+      expect(story.equals(other_story)).toBe(true)
+
+    it 'should return false if other story\'s is node of class story', ->
+      other_story = {id: story.id, title: story.title, nodes: story.nodes}
+      expect(story.equals(other_story)).toBe(false)
+
+    it 'should return false if other story\'s title is different', ->
+      other_story.title = 'Cloned title'
+      expect(story.equals(other_story)).toBe(false)
+
+    it 'should return false if other story\'s id is different', ->
+      other_story.id = 'Cloned id'
+      expect(story.equals(other_story)).toBe(false)
+
+    it 'should return false if other story\'s nodes different', ->
+      other_story = _.cloneDeep(story)
+      other_story.nodes = {test_node: 'test2', test_node_2: 'test'}
+      expect(story.equals(other_story)).toBe(false)
+
+
   describe '.from_json', ->
     it 'should correctly construct a Story from a story_id and the jsonified story', ->
       story_from_json = Story.from_json(story.id, story.to_json())
       expect(story_from_json).toEqual(jasmine.any(Story))
-      expect(_.isEqual(story_from_json, story)).toBe(true)
+      expect(story_from_json.equals(story)).toBe(true)
 
 
 describe 'StoryStorage', ->
@@ -117,5 +139,5 @@ describe 'StoryStorage', ->
     it 'should return an object containing all stories in storage as Story objects, using their ids as keys', ->
       stories = story_storage.stories()
       expect(_.keys(stories).length).toEqual(2)
-      expect(_.isEqual(stories[story1.id], story1)).toBe(true)
-      expect(_.isEqual(stories[story2.id], story2)).toBe(true)
+      expect(stories[story1.id].equals(story1)).toBe(true)
+      expect(stories[story2.id].equals(story2)).toBe(true)

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -13,19 +13,11 @@ describe 'DebugStory', ->
         expect(story.nodes.test_node).toEqual('test')
 
     describe 'if a node with the node_id of the new node exists', ->
-      beforeEach ->
+      it 'should throw an error, and leave nodes unchanged', ->
         story.nodes = {test_node: 'test'}
-        spyOn(window, 'alert')
-        story.add_node('test_node', 'test2')
-
-      it 'should not add a new node', ->
+        expect(-> story.add_node('test_node', 'test2')).toThrow()
         expect(Object.keys(story.nodes).length).toEqual(1)
-
-      it 'should not alter the node text of the pre-existing node', ->
         expect(story.nodes.test_node).toEqual('test')
-
-      it 'should pop up an alert', ->
-        expect(window.alert).toHaveBeenCalled()
 
   describe '#to_json', ->
     it 'should return plain javascript object in expected format', ->

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -25,9 +25,9 @@ describe 'Story', ->
       story.nodes = {test_node: 'test', test_node_2: 'test2'}
       expect(story.to_json()).toEqual({title: story.title, nodes: story.nodes})
 
-  describe '#update_title', ->
-    it 'should update the story\'s title to the specified value', ->
-      story.update_title('Test title')
+  describe '#set_title', ->
+    it 'should set the story\'s title to the specified value', ->
+      story.set_title('Test title')
       expect(story.title).toEqual('Test title')
 
   describe '#update_node_id', ->

--- a/app/editor/story.spec.coffee
+++ b/app/editor/story.spec.coffee
@@ -76,10 +76,50 @@ describe 'DebugStory', ->
 
 describe 'DebugStoryStorage', ->
 
+  story_storage = undefined
+  localStorage = undefined
+  story1 = undefined
+  story2 = undefined
+
   beforeEach ->
+    story1 = new DebugStory()
+    story2 = new DebugStory()
+    localStorage = new MockLocalStorage()
+    story_storage = new DebugStoryStorage(localStorage)
+    localStorage.setItem(story1.id, JSON.stringify(story1.to_json()))
+    localStorage.setItem(story2.id, JSON.stringify(story2.to_json()))
 
   describe '#clear', ->
+    beforeEach ->
+      localStorage.setItem('test', 'test value')
+      story_storage.clear()
+
+    it 'should clear all keys beginning with "yarn-" from storage', ->
+      expect(localStorage.getItem(story1.id)).not.toBeDefined()
+      expect(localStorage.getItem(story2.id)).not.toBeDefined()
+
+    it 'should not clear keys that do not begin with "yarn-" from storage', ->
+      expect(localStorage.getItem('test')).toEqual('test value')
 
   describe '#save_story', ->
+    story = undefined
+
+    beforeEach ->
+      story = new DebugStory()
+      story_storage.save_story(story)
+
+    it 'should save the serialized story to storage with expected reference key', ->
+      serialized_story = JSON.stringify(story.to_json())
+      expect(localStorage.getItem(story.id)).toEqual(serialized_story)
+
+    it 'should save the compiled story to storage with expected reference key', ->
+      parser = new window.Yarn.DebugParser()
+      compiled_story = parser.compile_page(story.nodes)
+      expect(localStorage.getItem(story.id + '-story')).toEqual(compiled_story)
 
   describe '#stories', ->
+    it 'should return an object containing all stories in storage as DebugStory objects, using their ids as keys', ->
+      stories = story_storage.stories()
+      expect(_.keys(stories).length).toEqual(2)
+      expect(_.isEqual(stories[story1.id], story1)).toBe(true)
+      expect(_.isEqual(stories[story2.id], story2)).toBe(true)

--- a/app/index.html
+++ b/app/index.html
@@ -10,89 +10,7 @@
 
   <body ng-app="DebugEditorApp">
 
-    <div ng-controller="DebugEditorCtrl as debugEditor" class="container">
-
-      <h1>Yarn Debug Editor</h1>
-      <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
-
-      <div>
-        <h2>Choose a story:</h2>
-        <select class="form-control" required
-          ng-options="_story.title for (id, _story) in stories" ng-model="story">
-        </select>
-      </div>
-
-      <br/>
-
-      <div>
-        <button type="button" class="btn btn-primary"
-          ng-click="new_story()">
-          New Story
-        </button>
-        <button type="button" class="btn btn-primary"
-          ng-click="clear_stories()">
-          Clear Stories
-        </button>
-      </div>
-
-      <hr/>
-
-      <div>
-        <h2>
-          Editing story:
-          <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
-            {{ story.title }}
-          </a>
-        </h2>
-
-        <div>
-          <button type="button" class="btn btn-primary"
-              ng-click="launch_story()">
-            Play
-          </button>
-        </div>
-
-        <br/>
-
-        <div>
-          <form>
-            <div class="form-group">
-              <input class="form-control" placeholder="Node title" ng-model="new_node.node_id" required/>
-            </div>
-            <div class="form-group">
-              <textarea class="form-control" placeholder="Node text" ng-model="new_node.text"></textarea>
-            </div>
-            <input type="submit" class="btn btn-primary" value="Add A Node"
-              ng-click="add_node_to_story(new_node.node_id, new_node.text)" ng-disabled="!new_node.node_id"/>
-          </form>
-        </div>
-
-        <hr/>
-
-        <div ng-repeat="(node_id, text) in story.nodes">
-
-          <h2>Edit story nodes:</h2>
-
-          <div>
-            <h3>
-              <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
-                {{ node_id }}
-              </a>
-            </h3>
-            <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="story.update_node_text(node_id, $data)">
-              <pre>{{ text }}</pre>
-            </a>
-          </div>
-
-          <div ng-repeat="edge in graph.edges_by_node(node_id)">
-            Edges:
-            <a href="#{{ edge.destination }}">{{ edge.destination }}</a>
-          </div>
-
-        </div>
-      </div>
-
-    </div>
+    <div ng-view></div>
 
     <!-- bower:js -->
     <script src="bower_components/jquery/dist/jquery.js"></script>
@@ -101,6 +19,7 @@
     <script src="bower_components/angular-xeditable/dist/js/xeditable.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
     <script src="bower_components/undermore/bin/undermore.js"></script>
+    <script src="bower_components/angular-route/angular-route.js"></script>
     <!-- endbower -->
 
     <script type="text/javascript" src="main.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -15,20 +15,14 @@
       <h1>Yarn Debug Editor</h1>
       <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
 
-      <div ng-if="story_ids.length > 0">
-        <form ng-submit="edit_story(chosen_story_id)" >
-          <div class="form-group">
-            <select class="form-control" required
-              ng-options="story_id for story_id in story_ids" ng-model="chosen_story_id">
-              <option value="">Choose a story</option>
-            </select>
-          </div>
-          <button type="submit" class="btn btn-primary"
-            ng-disabled="!chosen_story_id">
-            Load Story
-          </button>
-        </form>
+      <div>
+        <h2>Choose a story</h2>
+        <select class="form-control" required
+          ng-options="_story.title for (id, _story) in stories" ng-model="story">
+        </select>
       </div>
+
+      <br/>
 
       <div>
         <button type="button" class="btn btn-primary"
@@ -41,13 +35,29 @@
         </button>
       </div>
 
+      <hr/>
+
       <div>
-        <h1>
+        <h2>
           Editing:
           <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
             {{ story.title }}
           </a>
-        </h1>
+        </h2>
+
+        <div>
+          <button type="button" class="btn btn-primary"
+              ng-click="save_story()">
+            Save
+          </button>
+
+          <button type="button" class="btn btn-primary"
+              ng-click="launch_story()">
+            Play Story
+          </button>
+        </div>
+
+        <br/>
 
         <div>
           <form>
@@ -65,11 +75,11 @@
         <div ng-repeat="(node_id, text) in story.nodes" class="row">
 
           <div class="col-xs-12">
-            <h2>
+            <h3>
               <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
                 {{ node_id }}
               </a>
-            </h2>
+            </h3>
             <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="story.update_node_text(node_id, $data)">
               <pre>{{ text }}</pre>
             </a>
@@ -81,16 +91,6 @@
           </div>
 
         </div>
-
-        <button type="button" class="btn btn-primary"
-            ng-click="save_story()">
-          Save
-        </button>
-
-        <button type="button" class="btn btn-primary"
-            ng-click="launch_story()">
-          Play Story
-        </button>
       </div>
 
     </div>

--- a/app/index.html
+++ b/app/index.html
@@ -16,7 +16,7 @@
       <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
 
       <div>
-        <h2>Choose a story</h2>
+        <h2>Choose a story:</h2>
         <select class="form-control" required
           ng-options="_story.title for (id, _story) in stories" ng-model="story">
         </select>
@@ -39,7 +39,7 @@
 
       <div>
         <h2>
-          Editing:
+          Editing story:
           <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
             {{ story.title }}
           </a>
@@ -47,13 +47,8 @@
 
         <div>
           <button type="button" class="btn btn-primary"
-              ng-click="save_story()">
-            Save
-          </button>
-
-          <button type="button" class="btn btn-primary"
               ng-click="launch_story()">
-            Play Story
+            Play
           </button>
         </div>
 
@@ -72,9 +67,13 @@
           </form>
         </div>
 
-        <div ng-repeat="(node_id, text) in story.nodes" class="row">
+        <hr/>
 
-          <div class="col-xs-12">
+        <div ng-repeat="(node_id, text) in story.nodes">
+
+          <h2>Edit story nodes:</h2>
+
+          <div>
             <h3>
               <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
                 {{ node_id }}
@@ -85,7 +84,7 @@
             </a>
           </div>
 
-          <div class="col-xs-12" ng-repeat="edge in graph.edges_by_node(node_id)">
+          <div ng-repeat="edge in graph.edges_by_node(node_id)">
             Edges:
             <a href="#{{ edge.destination }}">{{ edge.destination }}</a>
           </div>

--- a/app/index.html
+++ b/app/index.html
@@ -42,7 +42,7 @@
       </div>
 
       <div>
-        <h1>Editing {{ story.id }}</h1>
+        <h1>Editing {{ story.title }} - {{ story.id }}</h1>
 
         <div>
           <form>

--- a/app/index.html
+++ b/app/index.html
@@ -70,6 +70,7 @@
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-xeditable/dist/js/xeditable.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="bower_components/undermore/bin/undermore.js"></script>
     <!-- endbower -->
 
     <script type="text/javascript" src="main.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -42,7 +42,12 @@
       </div>
 
       <div>
-        <h1>Editing {{ story.title }} - {{ story.id }}</h1>
+        <h1>
+          Editing:
+          <a name="{{ story.title }}" editable-text="story.title" onbeforesave="story.update_title($data)">
+            {{ story.title }}
+          </a>
+        </h1>
 
         <div>
           <form>

--- a/app/index.html
+++ b/app/index.html
@@ -13,54 +13,80 @@
     <div ng-controller="DebugEditorCtrl as debugEditor" class="container">
 
       <h1>Yarn Debug Editor</h1>
-      <p>Add a node. Edit a node.</p>
+      <p>Choose a story. Make a new story. Add a node. Edit a node.</p>
 
-      <div>
-        <form>
+      <div ng-if="story_ids.length > 0">
+        <form ng-submit="edit_story(chosen_story_id)" >
           <div class="form-group">
-            <input ng-model="new_node.node_id" class="form-control" placeholder="Node title"/>
+            <select class="form-control" required
+              ng-options="story_id for story_id in story_ids" ng-model="chosen_story_id">
+              <option value="">Choose a story</option>
+            </select>
           </div>
-          <div class="form-group">
-            <textarea ng-model="new_node.text" class="form-control" placeholder="Node text"></textarea>
-          </div>
-          <button type="submit" ng-click="add_node(new_node.node_id, new_node.text)" class="btn btn-primary">Add A Node</button>
+          <button type="submit" class="btn btn-primary"
+            ng-disabled="!chosen_story_id">
+            Load Story
+          </button>
         </form>
       </div>
 
-      <div ng-repeat="(node_id, text) in nodes" class="row">
-
-        <div class="col-xs-12">
-          <h2>
-            <a name="{{ node_id }}" editable-text="node_id" onbeforesave="update_node_id(node_id, $data)">
-              {{ node_id }}
-            </a>
-          </h2>
-          <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="update_node_text(node_id, $data)">
-            <pre>{{ text }}</pre>
-          </a>
-        </div>
-
-        <div ng-repeat="edge in graph.edges_by_node(node_id)" class="col-xs-12">
-          Edges:
-          <a href="#{{ edge.destination }}">{{ edge.destination }}</a>
-        </div>
-
+      <div>
+        <button type="button" class="btn btn-primary"
+          ng-click="new_story()">
+          New Story
+        </button>
+        <button type="button" class="btn btn-primary"
+          ng-click="clear_stories()">
+          Clear Stories
+        </button>
       </div>
 
-      <button type="submit" class="btn btn-primary"
-          ng-click="save_story()">
-        Save
-      </button>
+      <div>
+        <h1>Editing {{ story.id }}</h1>
 
-      <button type="submit" class="btn btn-primary"
-          ng-click="launch_story()">
-        Play Story
-      </button>
+        <div>
+          <form>
+            <div class="form-group">
+              <input class="form-control" placeholder="Node title" ng-model="new_node.node_id" required/>
+            </div>
+            <div class="form-group">
+              <textarea class="form-control" placeholder="Node text" ng-model="new_node.text"></textarea>
+            </div>
+            <input type="submit" class="btn btn-primary" value="Add A Node"
+              ng-click="add_node_to_story(new_node.node_id, new_node.text)" ng-disabled="!new_node.node_id"/>
+          </form>
+        </div>
 
-      <button type="submit" class="btn btn-primary"
-          ng-click="new_story()">
-        Clear Story
-      </button>
+        <div ng-repeat="(node_id, text) in story.nodes" class="row">
+
+          <div class="col-xs-12">
+            <h2>
+              <a name="{{ node_id }}" editable-text="node_id" onbeforesave="story.update_node_id(node_id, $data)">
+                {{ node_id }}
+              </a>
+            </h2>
+            <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="story.update_node_text(node_id, $data)">
+              <pre>{{ text }}</pre>
+            </a>
+          </div>
+
+          <div class="col-xs-12" ng-repeat="edge in graph.edges_by_node(node_id)">
+            Edges:
+            <a href="#{{ edge.destination }}">{{ edge.destination }}</a>
+          </div>
+
+        </div>
+
+        <button type="button" class="btn btn-primary"
+            ng-click="save_story()">
+          Save
+        </button>
+
+        <button type="button" class="btn btn-primary"
+            ng-click="launch_story()">
+          Play Story
+        </button>
+      </div>
 
     </div>
 

--- a/app/play.html
+++ b/app/play.html
@@ -4,7 +4,7 @@
   <head>
     <script>
       (function() {
-        var story_id = localStorage.getItem('yarn-story-id');
+        var story_id = window.location.hash.slice(1);
         var storyHtml = localStorage.getItem(story_id + '-story');
         window.onload = function() {
           document.documentElement.innerHTML = storyHtml;

--- a/app/play.html
+++ b/app/play.html
@@ -4,7 +4,8 @@
   <head>
     <script>
       (function() {
-        var storyHtml = localStorage.getItem('yarnStory');
+        var story_id = localStorage.getItem('yarn-story-id');
+        var storyHtml = localStorage.getItem(story_id + '-story');
         window.onload = function() {
           document.documentElement.innerHTML = storyHtml;
         }

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "angular": "~1.3.x",
     "angular-xeditable": "~0.1.8",
     "bootstrap": "~3.3.2",
-    "jquery": "2.1.x"
+    "jquery": "2.1.x",
+    "undermore": "~1.8.5"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "angular-xeditable": "~0.1.8",
     "bootstrap": "~3.3.2",
     "jquery": "2.1.x",
-    "undermore": "~1.8.5"
+    "undermore": "~1.8.5",
+    "angular-route": "~1.3.15"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function(config){
       'app/bower_components/angular/angular.js',
       'app/bower_components/angular-xeditable/dist/js/xeditable.js',
       'app/bower_components/bootstrap/dist/js/bootstrap.js',
+      'app/bower_components/undermore/bin/undermore.js',
       // endbower
       'node_modules/angular-mocks/angular-mocks.js',
       'node_modules/mock-localstorage/lib/mock-localstorage.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function(config){
       'app/bower_components/angular-xeditable/dist/js/xeditable.js',
       'app/bower_components/bootstrap/dist/js/bootstrap.js',
       'app/bower_components/undermore/bin/undermore.js',
+      'app/bower_components/angular-route/angular-route.js',
       // endbower
       'node_modules/angular-mocks/angular-mocks.js',
       'node_modules/mock-localstorage/lib/mock-localstorage.js',


### PR DESCRIPTION
Addressing https://github.com/sarahquigley/yarn/issues/8 and https://github.com/sarahquigley/yarn/issues/13

- New users are presented with a largely empty screen, with a 'New Story' button with which they can begin creating their first story.
- All stories a User has created are persisted in localStorage until such a time as a user chooses to clear them.
- User can switch between stories.
- Stories can be loaded at a unique URL.
- Stories are played at a unique URL.