### PR TITLE
Auto generate nodes for edges

### DIFF
--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -49,8 +49,8 @@ angular.module('DebugEditorApp', [
   if $routeParams.id
     $scope.story = $scope.stories[$routeParams.id]
 
-  # Debug Editor Methods
-  $scope.go_to_story = () ->
+  # Debug Editor $scope Methods
+  $scope.go_to_story = ->
     story_id = if $scope.story then $scope.story.id else ''
     $location.path('/stories/' + story_id)
 
@@ -64,6 +64,14 @@ angular.module('DebugEditorApp', [
     try
       $scope.story.add_node(node_id, node_text)
       $scope.new_node = {}
+
+      $scope.graph = debugParser.compile_graph($scope.story.nodes)
+      edges = $scope.graph.edges_by_node(node_id)
+      for edge in edges
+        try
+          $scope.story.add_node(edge.destination, '')
+        catch error
+
     catch error
       alert(error)
 

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -111,8 +111,6 @@ describe 'DebugEditorApp', ->
             expect(window.alert).toHaveBeenCalled()
 
         describe 'if $scope.story.add_node returns true', ->
-          edges = undefined
-
           beforeEach ->
             edges = [
               new Yarn.Edge('source1', 'destination1'),

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -111,12 +111,35 @@ describe 'DebugEditorApp', ->
             expect(window.alert).toHaveBeenCalled()
 
         describe 'if $scope.story.add_node returns true', ->
+          edges = undefined
+
           beforeEach ->
+            edges = [
+              new Yarn.Edge('source1', 'destination1'),
+              new Yarn.Edge('source1', 'destination2')
+            ]
+
+            debugParser.compile_graph.and.callFake((nodes) ->
+              graph = new Yarn.Graph(nodes, [])
+              spyOn(graph, 'edges_by_node').and.returnValue(edges)
+              return graph
+            )
+
             spyOn($scope.story, 'add_node')
             $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
 
           it 'should set $scope.new_node to an empty object', ->
             expect($scope.new_node).toEqual({})
+
+          it 'should call debugParser.compile_graph', ->
+            expect(debugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
+
+          it 'should call $scope.graph.edges_by_node', ->
+            expect($scope.graph.edges_by_node).toHaveBeenCalledWith(new_node.id)
+
+          it 'should call $scope.story.add_node once for every edge in the new node', ->
+            expect($scope.story.add_node).toHaveBeenCalledWith('destination1', '')
+            expect($scope.story.add_node).toHaveBeenCalledWith('destination2', '')
 
       describe '.launch_story', ->
         it 'should play the story in a new window', ->

--- a/app/main.coffee
+++ b/app/main.coffee
@@ -2,7 +2,7 @@ class Edge
   constructor: (@source, @destination) ->
 
 class Graph
-  constructor: (@nodes = {}, @edges = {}) ->
+  constructor: (@nodes = {}, @edges = []) ->
     # TODO: some validation of the types!
     #
     # @nodes: dict of {node_id: node_text}


### PR DESCRIPTION
Addressing the following issue: https://github.com/sarahquigley/yarn/issues/15

Adds functionality such that when a user creates a new node, new nodes are created corresponding to each of those edges (unless that node is already present).