### PR TITLE
Generate nodes for edges on node update

### DIFF
--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -49,6 +49,15 @@ angular.module('DebugEditorApp', [
   if $routeParams.id
     $scope.story = $scope.stories[$routeParams.id]
 
+  # Private methods
+  add_nodes_for_node_edges = (node_id) ->
+    $scope.graph = debugParser.compile_graph($scope.story.nodes)
+    edges = $scope.graph.edges_by_node(node_id)
+    for edge in edges
+      try
+        $scope.story.add_node(edge.destination, '')
+      catch error
+
   # Debug Editor $scope Methods
   $scope.go_to_story = ->
     story_id = if $scope.story then $scope.story.id else ''
@@ -64,16 +73,13 @@ angular.module('DebugEditorApp', [
     try
       $scope.story.add_node(node_id, node_text)
       $scope.new_node = {}
-
-      $scope.graph = debugParser.compile_graph($scope.story.nodes)
-      edges = $scope.graph.edges_by_node(node_id)
-      for edge in edges
-        try
-          $scope.story.add_node(edge.destination, '')
-        catch error
-
+      add_nodes_for_node_edges(node_id)
     catch error
       alert(error)
+
+  $scope.update_node_text = (node_id, node_text) ->
+    $scope.story.update_node_text(node_id, node_text)
+    add_nodes_for_node_edges(node_id)
 
   $scope.launch_story = ->
     $window.open('/play.html#' + $scope.story.id)

--- a/app/editor/editor.coffee
+++ b/app/editor/editor.coffee
@@ -49,15 +49,6 @@ angular.module('DebugEditorApp', [
   if $routeParams.id
     $scope.story = $scope.stories[$routeParams.id]
 
-  # Private methods
-  add_nodes_for_node_edges = (node_id) ->
-    $scope.graph = debugParser.compile_graph($scope.story.nodes)
-    edges = $scope.graph.edges_by_node(node_id)
-    for edge in edges
-      try
-        $scope.story.add_node(edge.destination, '')
-      catch error
-
   # Debug Editor $scope Methods
   $scope.go_to_story = ->
     story_id = if $scope.story then $scope.story.id else ''
@@ -69,17 +60,22 @@ angular.module('DebugEditorApp', [
     $scope.stories[$scope.story.id] = $scope.story
     $scope.graph = debugParser.compile_graph($scope.story.nodes)
 
-  $scope.add_node_to_story = (node_id, node_text='') ->
-    try
-      $scope.story.add_node(node_id, node_text)
-      $scope.new_node = {}
-      add_nodes_for_node_edges(node_id)
-    catch error
-      alert(error)
-
   $scope.update_node_text = (node_id, node_text) ->
     $scope.story.update_node_text(node_id, node_text)
-    add_nodes_for_node_edges(node_id)
+    $scope.graph = debugParser.compile_graph($scope.story.nodes)
+    edges = $scope.graph.edges_by_node(node_id)
+    for edge in edges
+      try
+        $scope.story.add_node(edge.destination, '')
+      catch error
+
+  $scope.add_node_to_story = (node_id, node_text='') ->
+    try
+      $scope.story.add_node(node_id, '')
+      $scope.update_node_text(node_id, node_text)
+      $scope.new_node = {}
+    catch error
+      alert(error)
 
   $scope.launch_story = ->
     $window.open('/play.html#' + $scope.story.id)

--- a/app/editor/editor.html
+++ b/app/editor/editor.html
@@ -68,7 +68,7 @@
             {{ node_id }}
           </a>
         </h3>
-        <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="x_edit(story.update_node_text, node_id, $data)">
+        <a href="#" editable-textarea="text" e-rows="6" e-cols="40" onbeforesave="x_edit(update_node_text, node_id, $data)">
           <pre>{{ text }}</pre>
         </a>
       </div>

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -86,59 +86,6 @@ describe 'DebugEditorApp', ->
             $scope.go_to_story()
             expect($location.path).toHaveBeenCalledWith('/stories/')
 
-      describe '.add_node_to_story', ->
-        new_node = undefined
-
-        beforeEach ->
-          new_node = {id: 'Test Node', text: 'Test text'}
-          $scope.new_node = new_node
-
-        it 'should call $scope.story.add_node', ->
-          spyOn($scope.story, 'add_node')
-          $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
-          expect($scope.story.add_node).toHaveBeenCalledWith(new_node.id, new_node.text)
-
-        describe 'if $scope.story.add_node throws an error', ->
-          beforeEach ->
-            spyOn(window, 'alert')
-            spyOn($scope.story, 'add_node').and.callFake(-> throw "Error")
-            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
-
-          it 'should not set $scope.new_node to an empty object', ->
-            expect($scope.new_node).toEqual(new_node)
-
-          it 'should pop open an alert', ->
-            expect(window.alert).toHaveBeenCalled()
-
-        describe 'if $scope.story.add_node returns true', ->
-          beforeEach ->
-            edges = [
-              new Yarn.Edge('source1', 'destination1'),
-              new Yarn.Edge('source1', 'destination2')
-            ]
-
-            debugParser.compile_graph.and.callFake((nodes) ->
-              graph = new Yarn.Graph(nodes, [])
-              spyOn(graph, 'edges_by_node').and.returnValue(edges)
-              return graph
-            )
-
-            spyOn($scope.story, 'add_node')
-            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
-
-          it 'should set $scope.new_node to an empty object', ->
-            expect($scope.new_node).toEqual({})
-
-          it 'should call debugParser.compile_graph', ->
-            expect(debugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
-
-          it 'should call $scope.graph.edges_by_node', ->
-            expect($scope.graph.edges_by_node).toHaveBeenCalledWith(new_node.id)
-
-          it 'should call $scope.story.add_node once for every edge in the new node', ->
-            expect($scope.story.add_node).toHaveBeenCalledWith('destination1', '')
-            expect($scope.story.add_node).toHaveBeenCalledWith('destination2', '')
-
       describe '.update_node_text', ->
         node = undefined
 
@@ -172,6 +119,43 @@ describe 'DebugEditorApp', ->
           expect($scope.story.add_node).toHaveBeenCalledWith('destination1', '')
           expect($scope.story.add_node).toHaveBeenCalledWith('destination2', '')
 
+      describe '.add_node_to_story', ->
+        new_node = undefined
+
+        beforeEach ->
+          spyOn($scope, 'update_node_text')
+          new_node = {id: 'Test Node', text: 'Test text'}
+          $scope.new_node = new_node
+
+        it 'should call $scope.story.add_node', ->
+          spyOn($scope.story, 'add_node')
+          $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+          expect($scope.story.add_node).toHaveBeenCalledWith(new_node.id, '')
+
+        describe 'if $scope.story.add_node throws an error', ->
+          beforeEach ->
+            spyOn(window, 'alert')
+            spyOn($scope.story, 'add_node').and.callFake(-> throw "Error")
+            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+
+          it 'should not set $scope.new_node to an empty object', ->
+            expect($scope.new_node).toEqual(new_node)
+
+          it 'should not call $scope.update_node_text', ->
+            expect($scope.update_node_text).not.toHaveBeenCalled()
+
+          it 'should pop open an alert', ->
+            expect(window.alert).toHaveBeenCalled()
+
+        describe 'if $scope.story.add_node returns true', ->
+          beforeEach ->
+            $scope.add_node_to_story($scope.new_node.id, $scope.new_node.text)
+
+          it 'should set $scope.new_node to an empty object', ->
+            expect($scope.new_node).toEqual({})
+
+          it 'should call $scope.update_node_text', ->
+            expect($scope.update_node_text).toHaveBeenCalledWith(new_node.id, new_node.text)
 
       describe '.launch_story', ->
         it 'should play the story in a new window', ->

--- a/app/editor/editor.spec.coffee
+++ b/app/editor/editor.spec.coffee
@@ -139,6 +139,40 @@ describe 'DebugEditorApp', ->
             expect($scope.story.add_node).toHaveBeenCalledWith('destination1', '')
             expect($scope.story.add_node).toHaveBeenCalledWith('destination2', '')
 
+      describe '.update_node_text', ->
+        node = undefined
+
+        beforeEach ->
+          edges = [
+            new Yarn.Edge('source1', 'destination1'),
+            new Yarn.Edge('source1', 'destination2')
+          ]
+
+          debugParser.compile_graph.and.callFake((nodes) ->
+            graph = new Yarn.Graph(nodes, [])
+            spyOn(graph, 'edges_by_node').and.returnValue(edges)
+            return graph
+          )
+
+          spyOn($scope.story, 'update_node_text')
+          spyOn($scope.story, 'add_node')
+          node = {id: 'Test node', text: 'Test text'}
+          $scope.update_node_text(node.id, node.text)
+
+        it 'should call $scope.story.add_node', ->
+          expect($scope.story.update_node_text).toHaveBeenCalledWith(node.id, node.text)
+
+        it 'should call debugParser.compile_graph', ->
+          expect(debugParser.compile_graph).toHaveBeenCalledWith($scope.story.nodes)
+
+        it 'should call $scope.graph.edges_by_node', ->
+          expect($scope.graph.edges_by_node).toHaveBeenCalledWith(node.id)
+
+        it 'should call $scope.story.add_node once for every edge in the new node', ->
+          expect($scope.story.add_node).toHaveBeenCalledWith('destination1', '')
+          expect($scope.story.add_node).toHaveBeenCalledWith('destination2', '')
+
+
       describe '.launch_story', ->
         it 'should play the story in a new window', ->
           $scope.launch_story()


### PR DESCRIPTION
Addressing the following issue: https://github.com/sarahquigley/yarn/issues/22

With these changes, new nodes are added for a node's edges both when:
- the text of a node is updated.
- a new node is added.
In both scenarios, new nodes will only be added for edges that do not already have a corresponding node.

Previously, new nodes for edges would only be added when a new node was added - the update scenario was overlooked.