### PR TITLE
Deploy app to gh pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,15 @@ module.exports = function(grunt) {
               '*/**/*.html',
               '!bower_components/**/*.html',
             ]
+          },
+          {
+            expand: true,
+            dot: true,
+            cwd: '<%= config.dirs.app %>/bower_components/bootstrap/',
+            dest: '<%= config.dirs.build %>',
+            src: [
+              'fonts/**/*',
+            ]
           }
         ]
       }
@@ -172,6 +181,19 @@ module.exports = function(grunt) {
       // Run tests once
       single: {
         singleRun: true
+      }
+    },
+
+    // ng-annotate tries to make the code safe for minification automatically
+    // by using the Angular long form for dependency injection.
+    ngAnnotate: {
+      build: {
+        files: [{
+          expand: true,
+          cwd: '<%= config.dirs.dev %>/concat/scripts',
+          src: ['*.js'],
+          dest: '<%= config.dirs.dev %>/concat/scripts'
+        }]
       }
     },
 
@@ -323,6 +345,7 @@ module.exports = function(grunt) {
       'useminPrepare',
       'concat',
       'copy:build',
+      'ngAnnotate',
       'cssmin',
       'uglify',
       'filerev',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-filerev": "^2.3.1",
     "grunt-gh-pages": "^0.10.0",
     "grunt-karma": "~0.10.1",
+    "grunt-ng-annotate": "^0.10.0",
     "grunt-npm-install": "~0.2.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "~2.0.0",


### PR DESCRIPTION
A few minor tweaks were needed to the Gruntfile, in order to deploy Yarn to Github pages.